### PR TITLE
Style tabs to align with mockups

### DIFF
--- a/client/src/inside/components/Tabs.vue
+++ b/client/src/inside/components/Tabs.vue
@@ -29,4 +29,37 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style lang="scss" scoped>
+@import '../../scss/definitions';
+
+.tabs ul {
+  border-bottom: 0;
+  color: $grey20;
+  font-size: 18px;
+}
+
+.tabs {
+  ul {
+    margin-left: 0;
+  }
+
+  a {
+    border-bottom: 6px solid #fff;
+    color: $grey40;
+    justify-content: left;
+    margin-bottom: 0;
+    margin-right: 1em;
+    padding: 0;
+  }
+
+  li {
+    margin-top: 0;
+    min-width: 8em;
+    &.is-active a {
+      color: $black;
+      cursor: default;
+      border-bottom: 6px solid $brand-primary-hover;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
I could not get the thin border to align to the top of the thicker border so I just scraped the thin border. 
<img width="428" alt="screen shot 2019-03-03 at 11 16 02 am" src="https://user-images.githubusercontent.com/20425828/53700317-d5f4d000-3da5-11e9-944c-8d574b4679e6.png">
