### PR TITLE
MAR display issues

### DIFF
--- a/client/src/helpers/ehr-helper.js
+++ b/client/src/helpers/ehr-helper.js
@@ -91,10 +91,7 @@ export default class EhrHelp {
   }
 
   getAsLoadedPageData (pageKey) {
-    let pageDef = this.getPageDefinition(pageKey)
-    if (!pageDef.asLoadedData) {
-      pageDef = this.prepareAsLoadedData(pageKey)
-    }
+    let pageDef = this.prepareAsLoadedData(pageKey)
     return pageDef.asLoadedData
   }
 
@@ -145,8 +142,6 @@ export default class EhrHelp {
         })
       })
     }
-    // debugehr('prepareAsLoadedData as stored all data', data)
-    // debugehr('prepareAsLoadedData as stored page data', pageData.surgical)
     pageDef.asLoadedData = pageData
     return pageDef
   }

--- a/client/src/inside/components/EhrPageTable.vue
+++ b/client/src/inside/components/EhrPageTable.vue
@@ -104,8 +104,8 @@ export default {
     refresh () {
       let tableKey = this.tableDef.tableKey
       let pageKey = this.pageDataKey
-      // console.log('EhrPageTable refresh for page table key', pageKey, tableKey)
       let pageData = this.ehrHelp.getAsLoadedPageData(pageKey)
+      // console.log('EhrPageTable refresh pageKey:', pageKey, 'tableKey:', tableKey, 'pageData:', pageData)
       // store the current data into local data property for display
       this.tableData = pageData[tableKey]
       this.transposedColumns = this.tableDef.transposedColumns

--- a/client/src/inside/components/mar/MarRecord.vue
+++ b/client/src/inside/components/mar/MarRecord.vue
@@ -1,9 +1,10 @@
 <template lang="pug">
   div
-    div Who administered: {{ record.whoAdministered }}
-    div Scheduled time: {{ record.scheduledTime }}
+    div Administered by: {{ record.whoAdministered }}
+    div Scheduled for: {{ record.scheduledTime }}
     div Actual time: {{ record.actualTime }}
-    med-list(:medsList="record.medications")
+    div Medications:
+      med-list(class="medList", :medsList="record.medications")
 </template>
 
 <script>
@@ -23,6 +24,6 @@ export default {
 
 <style lang="scss" scoped>
   .medList {
-    margin-left: 30px;
+    margin-left: 20px;
   }
 </style>

--- a/client/src/inside/components/mar/MarTodayContent.vue
+++ b/client/src/inside/components/mar/MarTodayContent.vue
@@ -142,6 +142,6 @@ export default {
   flex: 1 0 20%;
 }
 .mar-column {
-  flex: 0 0 20%;
+  flex: 1 0 20%;
 }
 </style>

--- a/client/src/inside/components/mar/MedList.vue
+++ b/client/src/inside/components/mar/MedList.vue
@@ -1,27 +1,30 @@
 <template lang="pug">
-  div
-    div(class="medList", v-for="med in medsList")
-      div {{ med.medication }}, {{ med.dose }}, {{ med.route }}, {{ med.notes }}
-      // div Reason: {{ med.reason }}
-      // div Details: {{ med.details }}
-      // div Schedule Type: {{ med.scheduleType }}
-      // div Schedule: {{ med.scheduleTime }}
-      // div Notes: {{ med.notes }}
+  ul
+    li(class="medList", v-for="med in medsList")
+      div {{ medText(med) }}
 </template>
 
 <script>
+import MedOrder from './medOrder-entity'
+const MAX_LEN = 80
 export default {
   name: 'MedList',
   props: {
     medsList: { type: Array }
   },
   methods: {
+    medText (med) {
+      let text =  MedOrder.medOrderAsTextLine(med, MAX_LEN)
+      // console.log('MedList medText', text)
+      return text
+    }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-  .medList {
-    margin-left: 30px;
-  }
+ul {
+  margin-left: 5px;
+  list-style: circle outside;
+}
 </style>

--- a/client/src/inside/components/mar/mar-entity.js
+++ b/client/src/inside/components/mar/mar-entity.js
@@ -13,8 +13,6 @@ const DEFAULT_DAY = 0
 function validWho (text) { return text && text.trim().length > 0 }
 function validDay (text) { return (/^([0-9]+)$/.test(text))}
 
-
-
 /*
 MAR record:
 who,
@@ -49,6 +47,14 @@ export default class MarEntity {
     }
   }
 
+  asObjectForApi () {
+    let obj = Object.assign({},this._data)
+    let medsList = this._period && this._period.medsList ? this._period.medsList : []
+    obj.medications = medsList.map(m => m.data)
+    console.log('MarEntity asObjectForApi', obj)
+    return obj
+  }
+
   set data (obj) { this._data = obj }
   get data () { return this._data }
 
@@ -72,20 +78,10 @@ export default class MarEntity {
   set medications (list) { this._data.medications = list }
   get medications () { return this._data.medications}
 
-  // // TODO add validation to set period
-  // set periodInfo (p) { this._data.periodInfo = p }
-  // // p.medsList.forEach( med => {
-  // //   this_data.medications.push(med)
-  // // })
-  // // }
-  // get periodInfo () { return this._data.periodInfo }
-  //
-
   setPeriod (period) {
-    // console.log('MarEntity set period ', period)
     this.scheduledTime = period.key
-    // copy the med list but get the inner raw data so we can store it in the db
-    this.medications = period.medsList ? period.medsList.map(m => m.data) : []
+    this._period = period
+    this._data.medications = period.medsList
   }
 
   validate () {

--- a/client/src/inside/components/mar/mar-util.js
+++ b/client/src/inside/components/mar/mar-util.js
@@ -81,16 +81,6 @@ export default class MarHelper {
     return key
   }
 
-  medText (med) {
-    let space = ', '
-    let extract = t => t && t.trim().length > 0 ? space + t : ''
-    let markup = med.medication
-    markup += extract(med.dose)
-    markup += extract(med.route)
-    markup += extract(med.type)
-    markup += extract(med.notes)
-    return markup
-  }
 
   /**
    * Dialog validation for the MAR record dialog.  Expect input to contain properties:
@@ -113,7 +103,7 @@ export default class MarHelper {
     let marTableKey = this.getMarTableKey()
     let asLoadedPageData = this.getEhrData_MarPageData()
     let table = asLoadedPageData[marTableKey] || []
-    let aMar = aMarEntity.data
+    let aMar = aMarEntity.asObjectForApi()
     console.log('saveMarDialog key:', marTableKey, ', ', aMar)
     table.push(aMar)
     let payload = {

--- a/client/src/inside/components/mar/medOrder-entity.js
+++ b/client/src/inside/components/mar/medOrder-entity.js
@@ -12,10 +12,27 @@ export default class MedOrder {
       this.data = {
         medication: undefined,
         dose: undefined,
+        route: undefined,
         scheduleType: undefined,
         notes: undefined
       }
     }
+  }
+
+  static medOrderAsTextLine (med, maxLen) {
+    if (!med instanceof MedOrder) {
+      console.log('not MedOrder', med)
+      return 'error'
+    }
+    let space = ', '
+    let extract = t => t && t.trim().length > 0 ? space + t : ''
+    let markup = med.medication
+    markup += extract(med.dose)
+    markup += extract(med.route)
+    markup += extract(med.scheduleType)
+    markup += extract(med.scheduleTime)
+    markup += extract(med.notes)
+    return markup.length > maxLen ? markup.substr(0,maxLen) + '...' : markup
   }
 
   set data (obj) { this._data = obj }
@@ -30,6 +47,9 @@ export default class MedOrder {
 
   get dose () { return this._data.dose }
   set dose (text) { this._data.dose = text }
+
+  get route () { return this._data.route }
+  set route (text) { this._data.route = text }
 
   get scheduleType () { return this._data.scheduleType }
   set scheduleType (text) { this._data.scheduleType = text }

--- a/client/src/inside/components/mar/period-defs.js
+++ b/client/src/inside/components/mar/period-defs.js
@@ -20,9 +20,9 @@ export default class PeriodDefs {
     let periodKeys = []
     if (medOrdersPageDefs && medOrdersPageDefs.tables && medOrdersPageDefs.tables.length > 0) {
       let cells = medOrdersPageDefs.tables[0].tableCells
-      console.log('PeriodDefs constructor cells', cells)
+      // console.log('PeriodDefs constructor cells', cells)
       let medPeriods = cells.filter(cell => cell.level3Key === SCHEDULE_FIELDSET && cell.inputType === 'checkbox')
-      console.log('PeriodDefs constructor medPeriods', medPeriods)
+      // console.log('PeriodDefs constructor medPeriods', medPeriods)
       medPeriods.forEach(mp => {
         let k = mp.elementKey
         periodKeys.push(k)
@@ -71,13 +71,13 @@ export default class PeriodDefs {
     // console.log('merging ', medOrders)
     let periodDefs = this._periodDefs
     let periodKeys = this._periodKeys
-    console.log('mergeOrdersSchedules medOrders', medOrders)
-    console.log('mergeOrdersSchedules periodKeys', periodKeys)
+    // console.log('mergeOrdersSchedules medOrders', medOrders)
+    // console.log('mergeOrdersSchedules periodKeys', periodKeys)
     medOrders.forEach(medOrder => {
-      console.log('mergeOrdersSchedules medOrder', medOrder)
+      // console.log('mergeOrdersSchedules medOrder', medOrder)
       periodKeys.forEach(pk => {
         let period = periodDefs[pk]
-        console.log('mergeOrdersSchedules periodKey', pk, period, medOrder[pk])
+        // console.log('mergeOrdersSchedules periodKey', pk, period, medOrder[pk])
         if (medOrder.isScheduled(pk)) {
           period.addMedication(medOrder)
         }


### PR DESCRIPTION
Change EhrHelper to always recal as loaded data. There was no need try to use the cached value and the cached value did not work across the med list and mar pages.
Fix layout and composition of medication lists.