### PR TITLE
Scroll to top, Table labels, lint

### DIFF
--- a/client/src/inside/components/EhrPageTable.vue
+++ b/client/src/inside/components/EhrPageTable.vue
@@ -9,6 +9,7 @@
             td(v-for="cell in column", :class="tableElementCss(cell)") {{ cell.value }}
 
     div(v-if="!tableDef.isTransposed", class="row_table")
+      h2(v-show="showTableLabel") {{tableDef.label}}
       table.table_horizontal
         thead
           tr
@@ -48,7 +49,8 @@ export default {
   props: {
     pageDataKey: { type: String },
     ehrHelp: { type: Object },
-    tableDef: { type: Object }
+    tableDef: { type: Object },
+    showTableLabel: { type: Boolean }
   },
   computed: {
     showTableAddButton () {

--- a/client/src/inside/components/mar/MarTodayContent.vue
+++ b/client/src/inside/components/mar/MarTodayContent.vue
@@ -60,7 +60,7 @@ export default {
       console.log('this.$refs.refMarDialog',this.$refs.refMarDialog)
       this.$refs.refMarDialog.openMarDialog(period)
     },
-    saveMar(mar) {
+    saveMar (mar) {
       let help = new MarHelper(this.ehrHelp)
       help.saveMarDialog(mar).then(() => {
         this.$refs.refMarDialog.closeDialog()

--- a/client/src/inside/defs/current-visit-1.js
+++ b/client/src/inside/defs/current-visit-1.js
@@ -4,7 +4,7 @@ export default function () {
     visit: {
       pageTitle: "Visit details",
       pageDataKey: "visit",
-      generated: "2019-03-27T13:05:25-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -220,7 +220,7 @@ export default function () {
     vitals: {
       pageTitle: "Vital signs",
       pageDataKey: "vitals",
-      generated: "2019-03-27T13:05:25-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -800,7 +800,7 @@ export default function () {
     fluidBalance: {
       pageTitle: "Fluid balance",
       pageDataKey: "fluidBalance",
-      generated: "2019-03-27T13:05:25-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -988,11 +988,12 @@ export default function () {
     neurological: {
       pageTitle: "Neurological assessment",
       pageDataKey: "neurological",
-      generated: "2019-03-27T13:05:25-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
           tableKey: "table",
+          label: "Neurological",
           addButtonText: "Add a neurological assessment",
           tableCells: [
             {
@@ -3151,7 +3152,7 @@ export default function () {
     respiratory: {
       pageTitle: "Respiratory assessment",
       pageDataKey: "respiratory",
-      generated: "2019-03-27T13:05:25-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -4308,7 +4309,7 @@ export default function () {
     cardiovascular: {
       pageTitle: "Cardiovascular assessment",
       pageDataKey: "cardiovascular",
-      generated: "2019-03-27T13:05:25-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -5678,7 +5679,7 @@ export default function () {
     gastrointestinal: {
       pageTitle: "Gastrointestinal assessment",
       pageDataKey: "gastrointestinal",
-      generated: "2019-03-27T13:05:25-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {

--- a/client/src/inside/defs/current-visit-2.js
+++ b/client/src/inside/defs/current-visit-2.js
@@ -4,7 +4,7 @@ export default function () {
     genitourinary: {
       pageTitle: "Genitourinary assessment",
       pageDataKey: "genitourinary",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -1512,7 +1512,7 @@ export default function () {
     musculoskeletal: {
       pageTitle: "Musculoskeletal assessment",
       pageDataKey: "musculoskeletal",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -2175,7 +2175,7 @@ export default function () {
     pain: {
       pageTitle: "Pain assessment",
       pageDataKey: "pain",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -3032,7 +3032,7 @@ export default function () {
     biopsychosocial: {
       pageTitle: "Biopsychosocial assessment",
       pageDataKey: "biopsychosocial",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -4542,7 +4542,7 @@ export default function () {
     nonmedOrders: {
       pageTitle: "Orders",
       pageDataKey: "nonmedOrders",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -5022,7 +5022,7 @@ export default function () {
     referrals: {
       pageTitle: "Referrals to other disciplines",
       pageDataKey: "referrals",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -5335,7 +5335,7 @@ export default function () {
     labRequisitions: {
       pageTitle: "Lab requisitions",
       pageDataKey: "labRequisitions",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -5634,7 +5634,7 @@ export default function () {
     medicationOrders: {
       pageTitle: "Medication orders",
       pageDataKey: "medicationOrders",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -6188,7 +6188,7 @@ export default function () {
     medAdminRec: {
       pageTitle: "Medication administration records",
       pageDataKey: "medAdminRec",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -6477,7 +6477,7 @@ export default function () {
     dischargeSummary: {
       pageTitle: "Discharge summary",
       pageDataKey: "dischargeSummary",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -6780,7 +6780,7 @@ export default function () {
     billing: {
       pageTitle: "Billing",
       pageDataKey: "billing",
-      generated: "2019-03-27T13:05:41-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [

--- a/client/src/inside/defs/external-resources.js
+++ b/client/src/inside/defs/external-resources.js
@@ -4,7 +4,7 @@ export default function () {
     assessmentTools: {
       pageTitle: "Standardized assessment tools",
       pageDataKey: "assessmentTools",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -711,7 +711,7 @@ export default function () {
     codeLookup: {
       pageTitle: "Code lookup",
       pageDataKey: "codeLookup",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -753,7 +753,7 @@ export default function () {
     diagnosticCodes: {
       pageTitle: "Diagnostic codes (ICD-10)",
       pageDataKey: "diagnosticCodes",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -1104,7 +1104,7 @@ export default function () {
     interventionCodes: {
       pageTitle: "Intervention codes",
       pageDataKey: "interventionCodes",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -1411,7 +1411,7 @@ export default function () {
     careMixGroup: {
       pageTitle: "Case mix group",
       pageDataKey: "careMixGroup",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {

--- a/client/src/inside/defs/patient-chart.js
+++ b/client/src/inside/defs/patient-chart.js
@@ -4,7 +4,7 @@ export default function () {
     progressNotes: {
       pageTitle: "Progress notes",
       pageDataKey: "progressNotes",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -166,7 +166,7 @@ export default function () {
     carePlan: {
       pageTitle: "Interprofessional plan of care",
       pageDataKey: "carePlan",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -495,7 +495,7 @@ export default function () {
     consultants: {
       pageTitle: "Consults",
       pageDataKey: "consultants",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [],
@@ -506,7 +506,7 @@ export default function () {
     labResults: {
       pageTitle: "Laboratory results",
       pageDataKey: "labResults",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -674,7 +674,7 @@ export default function () {
     medicalImaging: {
       pageTitle: "Medical imaging",
       pageDataKey: "medicalImaging",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [],
@@ -685,7 +685,7 @@ export default function () {
     operationReports: {
       pageTitle: "Operative reports and anaesthesia record",
       pageDataKey: "operationReports",
-      generated: "2019-03-26T14:22:40-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [],

--- a/client/src/inside/defs/patient-profile.js
+++ b/client/src/inside/defs/patient-profile.js
@@ -4,7 +4,7 @@ export default function () {
     demographics: {
       pageTitle: "Demographics",
       pageDataKey: "demographics",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -498,7 +498,7 @@ export default function () {
     allergies: {
       pageTitle: "Allergies",
       pageDataKey: "allergies",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -543,7 +543,7 @@ export default function () {
     medical: {
       pageTitle: "Medical history",
       pageDataKey: "medical",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -570,7 +570,7 @@ export default function () {
     psychosocial: {
       pageTitle: "Psychosocial history",
       pageDataKey: "psychosocial",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -1003,11 +1003,12 @@ export default function () {
     surgical: {
       pageTitle: "Surgical history",
       pageDataKey: "surgical",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
           tableKey: "pastSurgery",
+          label: "Past surgery",
           addButtonText: "Add a past surgery",
           tableCells: [
             {
@@ -1154,6 +1155,7 @@ export default function () {
         },
         {
           tableKey: "previous",
+          label: "Previous admission",
           addButtonText: "Add a previous appointment",
           tableCells: [
             {
@@ -1377,7 +1379,7 @@ export default function () {
     immunization: {
       pageTitle: "Immunization history",
       pageDataKey: "immunization",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -1659,7 +1661,7 @@ export default function () {
     familyHistory: {
       pageTitle: "Family history",
       pageDataKey: "familyHistory",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasForm: true,
       page_form: {
         rows: [
@@ -1686,7 +1688,7 @@ export default function () {
     careTeam: {
       pageTitle: "Care team",
       pageDataKey: "careTeam",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
@@ -1767,11 +1769,12 @@ export default function () {
     pastAppointments: {
       pageTitle: "Past appointments",
       pageDataKey: "pastAppointments",
-      generated: "2019-03-27T13:19:53-07:00",
+      generated: "2019-03-27T21:49:30-07:00",
       hasTable: true,
       tables: [
         {
           tableKey: "encounters",
+          label: "Past encounters",
           addButtonText: "Add a past encounter",
           tableCells: [
             {
@@ -1897,6 +1900,7 @@ export default function () {
         },
         {
           tableKey: "outpatientAppointments",
+          label: "Outpatient appointments",
           addButtonText: "Add a past appointment",
           tableCells: [
             {

--- a/client/src/inside/views/Allergies.vue
+++ b/client/src/inside/views/Allergies.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Allergies page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: allergies
       p Full path: /ehr/patient/allergies
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/AssessmentTools.vue
+++ b/client/src/inside/views/AssessmentTools.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Assessment Tools page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: assessment-tools
       p Full path: /ehr/external/assessment-tools
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Assessments.vue
+++ b/client/src/inside/views/Assessments.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Assessments page is generated.
@@ -18,6 +18,7 @@
       p Redirect: neurological
       p Route name: assessments
       p Full path: /ehr/current/assessments
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Billing.vue
+++ b/client/src/inside/views/Billing.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Billing page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: billing
       p Full path: /ehr/current/billing
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Biopsychosocial.vue
+++ b/client/src/inside/views/Biopsychosocial.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Biopsychosocial page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: biopsychosocial
       p Full path: /ehr/current/assessments/biopsychosocial
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Cardiovascular.vue
+++ b/client/src/inside/views/Cardiovascular.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Cardiovascular page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: cardiovascular
       p Full path: /ehr/current/assessments/cardiovascular
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/CareMixGroup.vue
+++ b/client/src/inside/views/CareMixGroup.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Care Mix Group page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: care-mix-group
       p Full path: /ehr/external/care-mix-group
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/CarePlan.vue
+++ b/client/src/inside/views/CarePlan.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Care Plan page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: care-plan
       p Full path: /ehr/chart/care-plan
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/CareTeam.vue
+++ b/client/src/inside/views/CareTeam.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Care Team page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: care-team
       p Full path: /ehr/patient/care-team
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Chart.vue
+++ b/client/src/inside/views/Chart.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Chart page is generated.
@@ -18,6 +18,7 @@
       p Redirect: progress-notes
       p Route name: chart
       p Full path: /ehr/chart
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/CodeLookup.vue
+++ b/client/src/inside/views/CodeLookup.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Code Lookup page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: code-lookup
       p Full path: /ehr/external/code-lookup
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Consults.vue
+++ b/client/src/inside/views/Consults.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Consults page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: consults
       p Full path: /ehr/chart/reports/consults
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Current.vue
+++ b/client/src/inside/views/Current.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Current page is generated.
@@ -18,6 +18,7 @@
       p Redirect: visit-details
       p Route name: current
       p Full path: /ehr/current
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Demographics.vue
+++ b/client/src/inside/views/Demographics.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Demographics page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: demographics
       p Full path: /ehr/patient/demographics
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/DiagnosticCodes.vue
+++ b/client/src/inside/views/DiagnosticCodes.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Diagnostic Codes page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: diagnostic-codes
       p Full path: /ehr/external/diagnostic-codes
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/DiagnosticReports.vue
+++ b/client/src/inside/views/DiagnosticReports.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Diagnostic Reports page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: diagnostic-reports
       p Full path: /ehr/chart/reports/diagnostic-reports
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Discharge.vue
+++ b/client/src/inside/views/Discharge.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Discharge page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: discharge
       p Full path: /ehr/current/discharge
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/External.vue
+++ b/client/src/inside/views/External.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This External page is generated.
@@ -18,6 +18,7 @@
       p Redirect: assessment-tools
       p Route name: external
       p Full path: /ehr/external
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/FamilyHistory.vue
+++ b/client/src/inside/views/FamilyHistory.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Family History page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: family-history
       p Full path: /ehr/patient/history/family-history
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/FluidBalance.vue
+++ b/client/src/inside/views/FluidBalance.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Fluid Balance page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: fluid-balance
       p Full path: /ehr/current/fluid-balance
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Gastrointestinal.vue
+++ b/client/src/inside/views/Gastrointestinal.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Gastrointestinal page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: gastrointestinal
       p Full path: /ehr/current/assessments/gastrointestinal
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Genitourinary.vue
+++ b/client/src/inside/views/Genitourinary.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Genitourinary page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: genitourinary
       p Full path: /ehr/current/assessments/genitourinary
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/History.vue
+++ b/client/src/inside/views/History.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This History page is generated.
@@ -18,6 +18,7 @@
       p Redirect: medical
       p Route name: history
       p Full path: /ehr/patient/history
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Immunization.vue
+++ b/client/src/inside/views/Immunization.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Immunization page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: immunization
       p Full path: /ehr/patient/history/immunization
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/InterventionCodes.vue
+++ b/client/src/inside/views/InterventionCodes.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Intervention Codes page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: intervention-codes
       p Full path: /ehr/external/intervention-codes
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/LabReports.vue
+++ b/client/src/inside/views/LabReports.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Lab Reports page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: lab-reports
       p Full path: /ehr/chart/reports/lab-reports
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/LabRequisitions.vue
+++ b/client/src/inside/views/LabRequisitions.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Lab Requisitions page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: lab-requisitions
       p Full path: /ehr/current/no-med/lab-requisitions
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Medical.vue
+++ b/client/src/inside/views/Medical.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Medical page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: medical
       p Full path: /ehr/patient/history/medical
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Meds.vue
+++ b/client/src/inside/views/Meds.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Meds page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: meds
       p Full path: /ehr/current/meds
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Musculoskeletal.vue
+++ b/client/src/inside/views/Musculoskeletal.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Musculoskeletal page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: musculoskeletal
       p Full path: /ehr/current/assessments/musculoskeletal
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Neurological.vue
+++ b/client/src/inside/views/Neurological.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Neurological page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: neurological
       p Full path: /ehr/current/assessments/neurological
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/NoMed.vue
+++ b/client/src/inside/views/NoMed.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This No Med page is generated.
@@ -18,6 +18,7 @@
       p Redirect: no-med-orders
       p Route name: no-med
       p Full path: /ehr/current/no-med
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/NoMedOrders.vue
+++ b/client/src/inside/views/NoMedOrders.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This No Med Orders page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: no-med-orders
       p Full path: /ehr/current/no-med/no-med-orders
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/OperativeAnaesthesia.vue
+++ b/client/src/inside/views/OperativeAnaesthesia.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Operative Anaesthesia page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: operative-anaesthesia
       p Full path: /ehr/chart/reports/operative-anaesthesia
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Pain.vue
+++ b/client/src/inside/views/Pain.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Pain page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: pain
       p Full path: /ehr/current/assessments/pain
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/PastAppointments.vue
+++ b/client/src/inside/views/PastAppointments.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Past Appointments page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: past-appointments
       p Full path: /ehr/patient/past-appointments
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Patient.vue
+++ b/client/src/inside/views/Patient.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Patient page is generated.
@@ -18,6 +18,7 @@
       p Redirect: demographics
       p Route name: patient
       p Full path: /ehr/patient
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/ProgressNotes.vue
+++ b/client/src/inside/views/ProgressNotes.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Progress Notes page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: progress-notes
       p Full path: /ehr/chart/progress-notes
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Psychosocial.vue
+++ b/client/src/inside/views/Psychosocial.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Psychosocial page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: psychosocial
       p Full path: /ehr/patient/history/psychosocial
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Referrals.vue
+++ b/client/src/inside/views/Referrals.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Referrals page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: referrals
       p Full path: /ehr/current/no-med/referrals
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Reports.vue
+++ b/client/src/inside/views/Reports.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Reports page is generated.
@@ -18,6 +18,7 @@
       p Redirect: consults
       p Route name: reports
       p Full path: /ehr/chart/reports
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Respiratory.vue
+++ b/client/src/inside/views/Respiratory.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Respiratory page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: respiratory
       p Full path: /ehr/current/assessments/respiratory
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/Surgical.vue
+++ b/client/src/inside/views/Surgical.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Surgical page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: surgical
       p Full path: /ehr/patient/history/surgical
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/inside/views/VisitDetails.vue
+++ b/client/src/inside/views/VisitDetails.vue
@@ -8,7 +8,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This Visit Details page is generated.
@@ -18,6 +18,7 @@
       p Redirect: 
       p Route name: visit-details
       p Full path: /ehr/current/visit-details
+      p {{uiProps}}
 </template>
 
 <script>
@@ -46,6 +47,10 @@ export default {
   computed: {
     uiProps () {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls () {
       return this.ehrHelp.showPageFormControls()

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -30,10 +30,38 @@ routes.push({
     import(/* webpackChunkName: "notfound" */ './outside/components/PageNotFound.vue')
 })
 
+
+/**
+ * scrollBehavior:
+ * See https://router.vuejs.org/guide/advanced/scroll-behavior.html
+ * @param to
+ * @param from
+ * @param savedPosition
+ * @return {*}
+ */
+const scrollBehavior = function (to, from, savedPosition) {
+  if (savedPosition) {
+    // savedPosition is only available for popstate navigations.
+    return savedPosition
+  } else {
+    const position = {}
+    if (to.hash) {
+      // scroll to anchor by returning the selector
+      position.selector = to.hash
+    } else {
+      // scroll to top
+      position.x = 0
+      position.y = 0
+    }
+    return position
+  }
+}
+
 const router = new Router({
   mode: 'history',
   base: process.env.BASE_URL,
-  routes: routes
+  routes: routes,
+  scrollBehavior
 })
 
 router.beforeEach((to, from, next) => {

--- a/client/tests/unit/ContextMock.js
+++ b/client/tests/unit/ContextMock.js
@@ -34,7 +34,7 @@ export default class {
     this.mock.push(`[clearRect, ${x}, ${y}, ${w}, ${h}] `)
   }
 
-  setLineDash(array)
+  setLineDash (array)
   {
     this.mock.push('[setLineDash]')
   }

--- a/client/tests/unit/mar/mar-summary.spec.js
+++ b/client/tests/unit/mar/mar-summary.spec.js
@@ -34,7 +34,7 @@ describe('MarSummary', () => {
     let row = tableBody[0]
     row.should.have.length(marRecords.length + 1/* for header */)
 
-    let cell, value, content, style
+    let cell, value, content
     cell = row[0]
     cell.should.have.property('type')
     cell.type.should.equal(MS.KEY_MED_ORDER)

--- a/client/tests/unit/mar/med-entity.spec.js
+++ b/client/tests/unit/mar/med-entity.spec.js
@@ -44,7 +44,7 @@ describe('MedOrder', () => {
     let str
     str = MedOrder.medOrderAsTextLine(med, 30)
     should.exist(str)
-    let invalidObj = function() {}
+    let invalidObj = function () {}
     str = MedOrder.medOrderAsTextLine(invalidObj, 30)
     should.exist(str)
     str.should.equal('error')

--- a/client/tests/unit/mar/med-test-util.js
+++ b/client/tests/unit/mar/med-test-util.js
@@ -66,7 +66,7 @@ export function getMedOrderPageDataSample () {
   }
 }
 
-export function getSampleMarDbDataList(cnt) {
+export function getSampleMarDbDataList (cnt) {
   let sample = getMarPageDataSample()
   let sampleList = sample.medAdminRec.table
   if (cnt ) {

--- a/makeEhr/generators/raw-input-to-def.js
+++ b/makeEhr/generators/raw-input-to-def.js
@@ -333,6 +333,7 @@ class RawInputToDef {
         })
 
         let table = { tableKey: container.containerKey,
+          label: container.label,
           addButtonText: container.addButtonText,
           tableCells: reducedCells,
           tableForm: tableForm }

--- a/makeEhr/source/ehrTemplate.txt
+++ b/makeEhr/source/ehrTemplate.txt
@@ -7,7 +7,7 @@
       div(class="region ehr-page-content")
         ehr-page-form(v-if="uiProps.hasForm", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey",)
         div(v-if="uiProps.hasTable", v-for="tableDef in uiProps.tables", :key="tableDef.tableKey")
-          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
+          ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :showTableLabel="showTableLabel")
       div Page updated: {{ ehrHelp.formatDate(uiProps.generated) }}
     div(style="display:none")
       p This {title} page is generated.
@@ -17,6 +17,7 @@
       p Redirect: {redirect}
       p Route name: {routeName}
       p Full path: {path}
+      p {{uiProps}}
 </template>
 
 <script>
@@ -45,6 +46,10 @@ export default {
   computed: {
     uiProps() {
       return this.ehrHelp ? this.ehrHelp.getPageDefinition(this.pageDataKey) : {}
+    },
+    showTableLabel () {
+      let tbls = this.uiProps.tables || []
+      return tbls.length > 1
     },
     showPageFormControls() {
       return this.ehrHelp.showPageFormControls()


### PR DESCRIPTION
Fix lint issues missed in the Mar commit.
Scroll to top on page navigation when using the nav bar.
Show table label when there are two or more tables and they are horizontal.