### PR TITLE
Datepicker, Vitals, Page elements

### DIFF
--- a/client/src/inside/components/EhrDialogFormElement.vue
+++ b/client/src/inside/components/EhrDialogFormElement.vue
@@ -13,7 +13,8 @@
 
     div(v-if="element.inputType === 'date'", class="date_wrapper")
       label(v-if="!(element.formOption === 'hideLabel')", class="date_label") {{element.label}}
-      datepicker(v-model="inputVal")
+      datepicker(class="d-picker", typeable="true", v-model="inputVal")
+        div(v-if="(element.formOption === 'hideLabel')", slot="beforeCalendarHeader", class="datepicker-header") {{element.label}}
 
     div(v-if="element.inputType === 'day'", class="day_wrapper")
       label(v-if="!(element.formOption === 'hideLabel')", class="day_label") {{element.label}}

--- a/client/src/inside/components/EhrPageForm.vue
+++ b/client/src/inside/components/EhrPageForm.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  div
+  div(class="ehr-page-form")
     div(:class="row.classList", class="columns", v-for="row in formDefs.rows", v-bind:key="row.rowNumber")
       div(class="column", :class="[formColClass(element)]", v-for="element in row.elements", v-bind:key="element.elementKey")
         ehr-page-form-element(:notEditing="notEditing", :element="element", :ehrHelp="ehrHelp" :inputs="theData")

--- a/client/src/inside/components/EhrPageFormElement.vue
+++ b/client/src/inside/components/EhrPageFormElement.vue
@@ -13,8 +13,8 @@
 
     div(v-if="element.inputType === 'date'", class="date_wrapper")
       label(v-if="!(element.formOption === 'hideLabel')", class="date_label") {{element.label}}
-      datepicker(class="input", v-bind:disabled="notEditing", v-bind:name="element.elementKey", v-model="inputVal")
-
+      datepicker(class="d-picker", typeable="true", v-bind:disabled="notEditing", v-bind:name="element.elementKey", v-model="inputVal")
+        div(v-if="(element.formOption === 'hideLabel')", slot="beforeCalendarHeader", class="datepicker-header") {{element.label}}
     div(v-if="element.inputType === 'day'", class="day_wrapper")
       label(v-if="!(element.formOption === 'hideLabel')", class="day_label") {{element.label}}
       input(class="input", v-bind:disabled="notEditing", v-bind:name="element.elementKey", v-model="inputVal")

--- a/client/src/inside/components/EhrPageTable.vue
+++ b/client/src/inside/components/EhrPageTable.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  div
+  div(class="ehr-page-table")
     div(v-show="showTableAddButton")
       ui-button(v-on:buttonClicked="showDialog") {{ tableDef.addButtonText }}
     div(v-if="tableDef.isTransposed", class="column_table")

--- a/client/src/inside/components/Vitals.vue
+++ b/client/src/inside/components/Vitals.vue
@@ -1,12 +1,12 @@
 <template lang="pug">
   div(class="content")
     tabs
-      tab(name="Chart")
-        ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
       tab(name="Graph",:selected="true")
         ui-button(v-on:buttonClicked="showDialog") {{ tableDef.addButtonText }}
         vitals-chart(v-bind:vitals="tableData", v-bind:vitalsModel="vitalsModel")
         ehr-dialog-form(:ehrHelp="ehrHelp", :pageDataKey="pageDataKey", :tableDef="tableDef", :inputs="inputs", :errorList="errorList" )
+      tab(name="Chart")
+        ehr-page-table(:tableDef="tableDef", :ehrHelp="ehrHelp", :pageDataKey="pageDataKey")
 
     div(style="display:none") Vitals: {{refreshData}}
 </template>

--- a/client/src/scss/styles/_forms.scss
+++ b/client/src/scss/styles/_forms.scss
@@ -290,6 +290,10 @@ select {
   }
 }
 
+.datepicker-header {
+  text-align: center;
+}
+
 .z-10 {
   z-index: 10;
 }


### PR DESCRIPTION
datepicker - properly disabled, can edit date as text, can delete an existing date, display the element label in the header of the calendar.
Vitals: reorganize the tabs
PageForm and Table elements now have a class for styling these top level elements.