### PR TITLE
MAR - fix data storage, visual day break in summary

### DIFF
--- a/client/src/inside/components/mar/MarSummary.vue
+++ b/client/src/inside/components/mar/MarSummary.vue
@@ -14,8 +14,8 @@
 
       tbody
         tr(v-for="row in tableBody")
-          td(v-for="cell in row")
-            div(:class="marCellStyle(cell)") {{marCellContent(cell)}}
+          td(v-for="(cell, index) in row", :class="tdStyle(cell, index, row)")
+            div(:class="marCellStyle(cell, index, row)") {{marCellContent(cell)}}
     hr
 </template>
 
@@ -46,17 +46,39 @@ export default {
     ehrHelp: { type: Object }
   },
   methods: {
-    marCellContent (cell) {  return this.marSummary.marCellContent(cell) },
-    marCellStyle (cell) {  return this.marSummary.marCellStyle(cell) },
+    marCellContent (cell) {
+      return this.marSummary.marCellContent(cell)
+    },
+    marCellStyle (cell, index, row) {
+      return this.marSummary.marCellStyle(cell)
+    },
+    tdStyle (cell, index, row) {
+      // We want to put a break between the days so find when the day changes.
+      // This assumes the sort order is largest (newest) day is first.
+      let style = ''
+      if (index + 1 < row.length) {
+        let nextCell = row[index+1]
+        let cellDay = cell.value.day
+        let nextDay = nextCell.value.day
+        // console.log('cellDay nextDay',cellDay, nextDay)
+        if (nextDay < cellDay) {
+          style = 'dayBreak'
+        }
+      }
+      return style
+    },
     refreshContent () {
       if(this.ehrHelp){
         let summary = this.marSummary
         let help = this.marHelper
         help.refreshMarData()
         summary.summaryRefresh(help.marRecords, help.theMedOrders)
-        console.log('MarSummary component.refresh()', summary)
+        // console.log('MarSummary component.refresh()', summary)
         this.tableHeader = summary.tableHeader
         this.tableBody = summary.tableBody
+        // console.log('MarSummary component.refresh() summary.tableBody', summary.tableBody)
+        // reset the previous day value stored for provide visual day break styles
+        this.prevDay = undefined
       }
     }
   },
@@ -91,4 +113,7 @@ export default {
   color:green;
 }
 
+.dayBreak {
+  border-right: 1px solid black !important;
+}
 </style>

--- a/client/src/inside/components/mar/mar-entity.js
+++ b/client/src/inside/components/mar/mar-entity.js
@@ -35,7 +35,7 @@ export default class MarEntity {
       this._data.medications = period.medsList
     } else if (typeof whoOrObj === 'object') { // from database
       // console.log('MarEntity create from object', whoOrObj)
-      this._data = whoOrObj
+      this._data = whoOrObj._data ? whoOrObj._data : whoOrObj
       this._data.medications = this._data.medications.map( mo => new MedOrder(mo))
       // console.log('MarEntity  this._data.medications', this._data.medications)
     }

--- a/client/src/inside/components/mar/mar-helper.js
+++ b/client/src/inside/components/mar/mar-helper.js
@@ -46,6 +46,8 @@ export default class MarHelper {
   getEhrData_MarRecords () {
     let marTableKey = this.getMarTableKey()
     let raw = this.getEhrData_MarPageData()[marTableKey] || []
+    // raw = Object.assign({}, raw)
+    // console.log('getEhrData_MarRecords', JSON.stringify(raw))
     let records = raw.map( m => new MarEntity(m))
     records.sort( (a,b) => MarEntity.compare(a, b) )
     return records
@@ -86,7 +88,7 @@ export default class MarHelper {
     let asLoadedPageData = this.getEhrData_MarPageData()
     let table = asLoadedPageData[marTableKey] || []
     let aMar = aMarEntity.asObjectForApi()
-    console.log('saveMarDialog key:', marTableKey, ', ', aMar)
+    // console.log('saveMarDialog key:', marTableKey, ', ', aMar)
     table.push(aMar)
     let payload = {
       propertyName: MAR_PAGE_KEY,

--- a/client/src/inside/components/mar/mar-summary.js
+++ b/client/src/inside/components/mar/mar-summary.js
@@ -41,8 +41,11 @@ export default class MarSummary {
       medMar.push(_createElement(MS.KEY_MED_ORDER, medOrder))
       marRecords.forEach( mar => {
         let marMedications = mar.medications
-        if(db2) console.log('MarSummary.summaryRefresh marMedications', marMedications)
-        let found = marMedications.find( m => m.medication === medName)
+        if(db2) console.log('MarSummary.summaryRefresh mar', mar, marMedications)
+        let found = marMedications.find( m => {
+          if(db2) console.log('m.medication === medName',m.constructor.name, m._data, medName)
+          return m.medication === medName
+        })
         medMar.push(found? _createElement(MS.KEY_MAR, mar) : EMPTY)
       })
       body.push(medMar)
@@ -71,6 +74,7 @@ export default class MarSummary {
   marCellStyle (cell) {
     let style = ''
     let type = cell.type
+    // console.log('marCellStyle', cell.type, cell.value)
     if( type === MS.KEY_MED_ORDER) {
       style = MS.CSS_CLASS_MED
     } else if( type === MS.KEY_MAR) {

--- a/client/src/inside/components/mar/med-entity.js
+++ b/client/src/inside/components/mar/med-entity.js
@@ -6,7 +6,7 @@
 
 export default class MedOrder {
   constructor (medOrObj) {
-    this._data = medOrObj
+    this._data = medOrObj && medOrObj._data ? medOrObj._data : medOrObj
   }
 
   static medOrderAsTextLine (med) {


### PR DESCRIPTION
When reading data back into the objects be sure to detect when the incoming object is a previous internal _data object.
Place a vertical bar in the summary table between days