### PR TITLE
Table transpose, seed editor view, instructor 

### DIFF
--- a/client/src/helpers/store-helper.js
+++ b/client/src/helpers/store-helper.js
@@ -164,7 +164,6 @@ class StoreHelperWorker {
     let assignment = visitInfo.assignment || {}
     let activity = visitInfo.activity || {}
     let activityData = component.$store.state.ehrData.sActivityData
-    let name = component.$store.state.visit.sUserInfo.fullName
     let currentEvaluationStudent = component.$store.getters['instructor/currentEvaluationStudent']
     let student = currentEvaluationStudent.user || {}
     // console.log('getPanelData: student', JSON.stringify(currentEvaluationStudent, null, 2))

--- a/client/src/inside/components/EhrContextBanner.vue
+++ b/client/src/inside/components/EhrContextBanner.vue
@@ -38,10 +38,10 @@ export default {
       return StoreHelper.isStudent(this)
     },
     showInstructor () {
-      return StoreHelper.isInstructor(this)
+      return StoreHelper.isInstructor(this) && !StoreHelper.isDevelopingContent(this)
     },
     showSeeding () {
-      return false
+      return StoreHelper.isDevelopingContent(this)
     }
   },
   methods: {

--- a/client/src/inside/components/EhrContextDeveloper.vue
+++ b/client/src/inside/components/EhrContextDeveloper.vue
@@ -5,7 +5,7 @@
         div(class="textField") Name: {{ sSeedContent.name }}
         div(class="textField") Version: {{ sSeedContent.version}}
         div(class="textField") Description: {{ sSeedContent.description}}
-        div(class="textField") Ehr: {{ sSeedContent.ehrData}}
+        // div(class="textField") Ehr: {{ sSeedContent.ehrData}}
 </template>
 
 <script>

--- a/client/src/inside/components/page/EhrPageTable.vue
+++ b/client/src/inside/components/page/EhrPageTable.vue
@@ -7,8 +7,8 @@
     //div(v-else-if="isStacked", class="stacked_table")
     div
       h2(v-show="tableDef.label") {{tableDef.label}}
-      // ehr-table-vertical(:ehrHelp="ehrHelp", :tableDef="tableDef")
-      ehr-table-stacked(:ehrHelp="ehrHelp", :tableDef="tableDef", :tableForm="tableForm")
+      ehr-table-vertical(v-if="isVertical", :ehrHelp="ehrHelp", :tableDef="tableDef")
+      ehr-table-stacked(v-if="isStacked", :ehrHelp="ehrHelp", :tableDef="tableDef", :tableForm="tableForm")
     ehr-dialog-form(:ehrHelp="ehrHelp", :tableDef="tableDef", :errorList="errorList" )
 </template>
 
@@ -51,10 +51,12 @@ export default {
       return this.tableDef.tableKey
     },
     isVertical () {
-      return this.tableForm.isTransposed
+      let isVert = this.tableDef.form.formOption === 'transpose'
+      // console.log('EhrPageTable is table vertical? ', isVert,  this.tableDef.form.formOption)
+      return isVert
     },
     isStacked () {
-      return this.tableForm.isStacked
+      return ! this.isVertical
     },
     showTableAddButton () {
       return this.ehrHelp.showTableAddButton()
@@ -70,7 +72,7 @@ export default {
     },
     refresh () {
       this.tableForm = this.ehrHelp.getTable(this.tableKey)
-      console.log('EhrPageTable refresh ', this.tableKey, this.tableForm)
+      // console.log('EhrPageTable refresh ', this.tableKey, this.tableForm)
     }
   },
   mounted: function () {

--- a/client/src/inside/components/page/EhrTableStacked.vue
+++ b/client/src/inside/components/page/EhrTableStacked.vue
@@ -17,7 +17,7 @@
 
 <script>
 import EhrTableCommon from './EhrTableCommon'
-const debug = true
+const debug = false
 
 export default {
   extends: EhrTableCommon,

--- a/client/src/inside/components/page/EhrTableVertical.vue
+++ b/client/src/inside/components/page/EhrTableVertical.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
-  div tc {{transposedColumns[0]}}
+  div
     div(v-if="!hasData") There are no records or reports for the patient.
     div(v-else)
       table.table_vertical
         tbody
           tr(v-for="column in transposedColumns", :class="tableColumnCss(column)")
-            td(:class="transposeLabelCss(column)") {{column}}
+            td(:class="transposeLabelCss(column)")
               span(v-html="transposeLabel(column)")
             td(v-for="cell in transposeData(column)", :class="transposeValueCss(cell)") {{ getCellData(cell) }}
 </template>
@@ -45,7 +45,15 @@ export default {
       return column.slice(1,column.length)
     },
     getCellData (cell) {
-      return cell
+      // console.log('EhrTableVertical getCellData', cell)
+      let stack = cell.stack
+      let values = []
+      stack.forEach ( (c) => {
+        if (c.value) {
+          values.push(c.value)
+        }
+      })
+      return values.join(',')
     },
     tableColumnCss: function (column) {
       // let hide = 'hide-table-element'
@@ -62,7 +70,7 @@ export default {
     refresh () {
       this.tableForm = this.ehrHelp.getTable(this.tableKey)
       this.transposedColumns = this.tableForm.transposedColumns
-      console.log('EhrTableVertical table view refresh', this.transposedColumns)
+      // console.log('EhrTableVertical table view refresh', this.transposedColumns)
     }
   }
 }

--- a/client/src/inside/components/page/ehr-helper.js
+++ b/client/src/inside/components/page/ehr-helper.js
@@ -216,6 +216,7 @@ export default class EhrHelpV2 {
           tableForm.tableData = tableData
           tableForm.dbData = dbData
         }
+        if (dbTable) console.log('EhrHelpV2._loadTableData tableData', tableData)
         let combined = []
         let headerRow = []
         rowTemplate.forEach( (rt) => {
@@ -227,13 +228,13 @@ export default class EhrHelpV2 {
           combined.push(row)
         })
 
-        console.log('combined', combined)
-        let transpose = combined.map((col, i) => combined.map(row => row[i]))
-        console.log('combined, transpose', combined, transpose)
+        if (dbTable) console.log('EhrHelpV2 combined', combined)
+        let transpose = combined[0].map((col, i) => combined.map(row => row[i]))
+        if (dbTable) console.log('EhrHelpV2 transpose', transpose)
         tableForm.transposedColumns = transpose
 
         let len = tableData[0] ? tableData[0].length : -1
-        console.log('length of row of table data', len, rowTemplate.length)
+        if (dbTable) console.log('EhrHelpV2 length of row of table data', len, rowTemplate.length)
         if (dbTable) console.log('EhrHelpV2._loadTableData load tableForm', tableForm)
       })
     }

--- a/client/src/inside/defs-grid/current-visit-1.js
+++ b/client/src/inside/defs-grid/current-visit-1.js
@@ -130,7 +130,7 @@ export default function () {
           fqn: 'visit.transferOutTime'
         }
       ],
-      generated: '2019-08-30T17:00:21-07:00',
+      generated: '2019-09-04T11:04:11-07:00',
       pageElements: {
         pageForm: {
           elementKey: 'pageForm',
@@ -481,7 +481,7 @@ export default function () {
           fqn: 'vitals.flowRate'
         }
       ],
-      generated: '2019-08-30T17:00:21-07:00',
+      generated: '2019-09-04T11:04:11-07:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -601,6 +601,7 @@ export default function () {
           form: {
             elementKey: 'table',
             addButtonText: 'Add vital signs',
+            formOption: 'transpose',
             formKey: 'table',
             ehr_groups: [
               {
@@ -719,7 +720,7 @@ export default function () {
           fqn: 'fluidBalance.fluidOut'
         }
       ],
-      generated: '2019-08-30T17:00:21-07:00',
+      generated: '2019-09-04T11:04:11-07:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -1541,7 +1542,7 @@ export default function () {
           fqn: 'neurological.strokeAssessmentCalculation'
         }
       ],
-      generated: '2019-08-30T17:00:21-07:00',
+      generated: '2019-09-04T11:04:11-07:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -1810,6 +1811,7 @@ export default function () {
             elementKey: 'table',
             label: 'Neurological',
             addButtonText: 'Add a neurological assessment',
+            formOption: 'transpose',
             formKey: 'table',
             ehr_groups: [
               {
@@ -2317,7 +2319,7 @@ export default function () {
           fqn: 'respiratory.generalComments'
         }
       ],
-      generated: '2019-08-30T17:00:21-07:00',
+      generated: '2019-09-04T11:04:11-07:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -2458,6 +2460,7 @@ export default function () {
           form: {
             elementKey: 'table',
             addButtonText: 'Add a respiratory assessment',
+            formOption: 'transpose',
             formKey: 'table',
             ehr_groups: [
               {
@@ -3066,7 +3069,7 @@ export default function () {
           fqn: 'cardiovascular.comments'
         }
       ],
-      generated: '2019-08-30T17:00:21-07:00',
+      generated: '2019-09-04T11:04:11-07:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -3277,6 +3280,7 @@ export default function () {
           form: {
             elementKey: 'table',
             addButtonText: 'Add a cardiovascular assessment',
+            formOption: 'transpose',
             formKey: 'table',
             ehr_groups: [
               {
@@ -3754,7 +3758,7 @@ export default function () {
           fqn: 'gastrointestinal.comments'
         }
       ],
-      generated: '2019-08-30T17:00:21-07:00',
+      generated: '2019-09-04T11:04:11-07:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -3916,6 +3920,7 @@ export default function () {
           form: {
             elementKey: 'table',
             addButtonText: 'Add a gastrointestinal assessment',
+            formOption: 'transpose',
             formKey: 'table',
             ehr_groups: [
               {

--- a/client/src/inside/defs-grid/current-visit-2.js
+++ b/client/src/inside/defs-grid/current-visit-2.js
@@ -3265,6 +3265,7 @@ export default function () {
           form: {
             elementKey: 'table',
             addButtonText: 'Add an administration record',
+            formOption: 'customCode',
             formKey: 'table',
             ehr_groups: [
               {

--- a/client/src/outside/components/ClassList.vue
+++ b/client/src/outside/components/ClassList.vue
@@ -85,6 +85,8 @@ export default {
       return formatTimeStr(sv.activityData.lastDate)
     },
     goToEhr (studentVisit) {
+      // disable the develop content in case it is on
+      StoreHelper.setIsDevelopingContent(this, false)
       let studentId = studentVisit._id
       // Go to the first screen related to the assignent
       let name = '/ehr/patient/demographics'

--- a/makeEhrV2/gen_defs/input-to-def.js
+++ b/makeEhrV2/gen_defs/input-to-def.js
@@ -57,6 +57,7 @@ const formProperties  = [
   'elementKey',
   'label',
   'addButtonText',
+  'formOption',
   'formCss',
 ]
 

--- a/makeEhrV2/raw_data/current-visit-1.txt
+++ b/makeEhrV2/raw_data/current-visit-1.txt
@@ -22,7 +22,7 @@ Discharged}"	eCell	{Mandatory: TRUE}	eCell	eCell	eCell	{Data_case_study: Admitte
 {inputType: day}	eCell	{Label: Transfer out day}	{elementKey: transferOutDay}	{pN: 10}	{fN: 2}	{gN: 1}	{sgN: }	eCell	eCell	eCell	{tableColumn: 4}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: time}	eCell	{Label: Transfer out time}	{elementKey: transferOutTime}	{pN: 10}	{fN: 2}	{gN: 1}	{sgN: }	eCell	eCell	eCell	{tableColumn: 5}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: page}	{pRef: 15}	{Label: Vital signs}	{elementKey: vitals}	{pN: 11}	{fN: }	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: table_form}	eCell	eCell	{elementKey: table}	{pN: 11}	{fN: 1}	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	{addButtonText: Add vital signs}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: table_form}	eCell	eCell	{elementKey: table}	{pN: 11}	{fN: 1}	{gN: }	{sgN: }	eCell	{formOption: transpose}	eCell	eCell	eCell	{addButtonText: Add vital signs}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 11}	{fN: 1}	{gN: 1}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: record_header}	eCell	eCell	eCell	{pN: 11}	{fN: 1}	{gN: 1}	{sgN: }	eCell	eCell	eCell	{tableColumn: 1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 11}	{fN: 1}	{gN: 2}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
@@ -61,8 +61,8 @@ Optiflow}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 12}	{fN: 1}	{gN: 2}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: text}	eCell	{Label: Fluid In}	{elementKey: fluidIn}	{pN: 12}	{fN: 1}	{gN: 2}	{sgN: }	eCell	eCell	{tableLabel: Fluid In}	{tableColumn: 2}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: text}	eCell	{Label: Fluid Out}	{elementKey: fluidOut}	{pN: 12}	{fN: 1}	{gN: 2}	{sgN: }	eCell	eCell	{tableLabel: Fluid Out}	{tableColumn: 3}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: page}	{pRef: 18}	{Label: Neurological assessment}	{elementKey: neurological}	{pN: 14}	{fN: }	{gN: }	{sgN: }	eCell	eCell	{tableLabel: Text}	{tableColumn: 3}	{tableCss: hr-table}	eCell	{dependantOn: fluidOut}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: table_form}	eCell	{Label: Neurological}	{elementKey: table}	{pN: 14}	{fN: 1}	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	{addButtonText: Add a neurological assessment}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: page}	{pRef: 18}	{Label: Neurological assessment}	{elementKey: neurological}	{pN: 14}	{fN: }	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: table_form}	eCell	{Label: Neurological}	{elementKey: table}	{pN: 14}	{fN: 1}	{gN: }	{sgN: }	eCell	{formOption: transpose}	eCell	eCell	eCell	{addButtonText: Add a neurological assessment}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 14}	{fN: 1}	{gN: 1}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: record_header}	eCell	eCell	eCell	{pN: 14}	{fN: 1}	{gN: 1}	{sgN: }	eCell	eCell	eCell	{tableColumn: 1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 14}	{fN: 1}	{gN: 2}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
@@ -190,7 +190,7 @@ Unequal}"	eCell	eCell	eCell	eCell	eCell	{Data_case_study: Equal}	eCell	eCell
 2 = Profound hemi-inattention or extinction}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: calculatedValue}	eCell	{Label: <b>Stroke assessment calculation</b>}	{elementKey: strokeAssessmentCalculation}	{pN: 14}	{fN: 1}	{gN: 4}	{sgN: 1}	eCell	eCell	{tableLabel: Stroke Assessment}	{tableColumn: 36}	eCell	eCell	eCell	{Default_value: 0}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: page}	{pRef: 19}	{Label: Respiratory assessment}	{elementKey: respiratory}	{pN: 15}	{fN: }	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: table_form}	eCell	eCell	{elementKey: table}	{pN: 15}	{fN: 1}	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	{addButtonText: Add a respiratory assessment}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: table_form}	eCell	eCell	{elementKey: table}	{pN: 15}	{fN: 1}	{gN: }	{sgN: }	eCell	{formOption: transpose}	eCell	eCell	eCell	{addButtonText: Add a respiratory assessment}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 15}	{fN: 1}	{gN: 1}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: record_header}	eCell	eCell	eCell	{pN: 15}	{fN: 1}	{gN: 1}	{sgN: }	eCell	eCell	eCell	{tableColumn: 1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 15}	{fN: 1}	{gN: 2}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
@@ -250,7 +250,7 @@ Bloody}"	eCell	eCell	eCell	eCell	eCell	{Data_case_study: (nothing selected)}	eCe
 {inputType: text}	eCell	{Label: Sputum comments}	{elementKey: sputumComments}	{pN: 15}	{fN: 1}	{gN: 2}	{sgN: 3}	eCell	eCell	{tableLabel: Sputum comments}	{tableColumn: 17}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{Data_case_study: (no notes)}	eCell	eCell
 {inputType: textarea}	eCell	{Label: General comments}	{elementKey: generalComments}	{pN: 15}	{fN: 1}	{gN: 2}	{sgN: 3}	eCell	eCell	{tableLabel: General comments}	{tableColumn: 18}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{Data_case_study: (no notes)}	eCell	eCell
 {inputType: page}	{pRef: 20}	{Label: Cardiovascular}	{elementKey: cardiovascular}	{pN: 16}	{fN: }	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: table_form}	eCell	eCell	{elementKey: table}	{pN: 16}	{fN: 1}	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	{addButtonText: Add a cardiovascular assessment}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: table_form}	eCell	eCell	{elementKey: table}	{pN: 16}	{fN: 1}	{gN: }	{sgN: }	eCell	{formOption: transpose}	eCell	eCell	eCell	{addButtonText: Add a cardiovascular assessment}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 16}	{fN: 1}	{gN: 1}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: record_header}	eCell	eCell	eCell	{pN: 16}	{fN: 1}	{gN: 1}	{sgN: }	eCell	eCell	eCell	{tableColumn: 1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 16}	{fN: 1}	{gN: 2}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
@@ -315,18 +315,18 @@ Ankle
 Pedal
 Sacral
 Pitting}"	eCell	eCell	eCell	eCell	eCell	{Data_case_study: No}	eCell	eCell
-{inputType: select}	eCell	{Label: Nail bed colour: Right hand}	{elementKey: nailBedColourRightHand}	{pN: 16}	{fN: 1}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Nail bed colour: Right hand}	{tableColumn: 24}	eCell	eCell	eCell	eCell	"{Options: Pink 
+{inputType: select}	eCell	{Label: Nail bed colour: Right hand}	{elementKey: nailBedColourRightHand}	{pN: 16}	{fN: 1}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Nail bed colour: Right hand}	{tableColumn: 24}	eCell	eCell	eCell	eCell	"{Options: Pink
 Cyanotic}"	eCell	eCell	eCell	eCell	eCell	{Data_case_study: Pink}	eCell	eCell
-{inputType: select}	eCell	{Label: Nail bed colour: Left hand}	{elementKey: nailBedColourLeftHand}	{pN: 16}	{fN: 1}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Nail bed colour: Left hand}	{tableColumn: 25}	eCell	eCell	eCell	eCell	"{Options: Pink 
+{inputType: select}	eCell	{Label: Nail bed colour: Left hand}	{elementKey: nailBedColourLeftHand}	{pN: 16}	{fN: 1}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Nail bed colour: Left hand}	{tableColumn: 25}	eCell	eCell	eCell	eCell	"{Options: Pink
 Cyanotic}"	eCell	eCell	eCell	eCell	eCell	{Data_case_study: Pink}	eCell	eCell
-{inputType: select}	eCell	{Label: Nail bed colour: Right Foot}	{elementKey: nailBedColourRightFoot}	{pN: 16}	{fN: 1}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Nail bed colour: Right Foot}	{tableColumn: 26}	eCell	eCell	eCell	eCell	"{Options: Pink 
+{inputType: select}	eCell	{Label: Nail bed colour: Right Foot}	{elementKey: nailBedColourRightFoot}	{pN: 16}	{fN: 1}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Nail bed colour: Right Foot}	{tableColumn: 26}	eCell	eCell	eCell	eCell	"{Options: Pink
 Cyanotic}"	eCell	eCell	eCell	eCell	eCell	{Data_case_study: Pink}	eCell	eCell
-{inputType: select}	eCell	{Label: Nail bed colour: Left foot}	{elementKey: nailBedColourLeftFoot}	{pN: 16}	{fN: 1}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Nail bed colour: Left foot}	{tableColumn: 27}	eCell	eCell	eCell	eCell	"{Options: Pink 
+{inputType: select}	eCell	{Label: Nail bed colour: Left foot}	{elementKey: nailBedColourLeftFoot}	{pN: 16}	{fN: 1}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Nail bed colour: Left foot}	{tableColumn: 27}	eCell	eCell	eCell	eCell	"{Options: Pink
 Cyanotic}"	eCell	eCell	eCell	eCell	eCell	{Data_case_study: Pink}	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 16}	{fN: 1}	{gN: 4}	{sgN: }	{formCss: full-grid}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: textarea}	eCell	{Label: Comments}	{elementKey: comments}	{pN: 16}	{fN: 1}	{gN: 4}	{sgN: }	eCell	eCell	{tableLabel: Comments}	{tableColumn: 28}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{Data_case_study: (blank)}	eCell	eCell
 {inputType: page}	{pRef: 21}	{Label: Gastrointestinal}	{elementKey: gastrointestinal}	{pN: 17}	{fN: }	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: table_form}	eCell	eCell	{elementKey: table}	{pN: 17}	{fN: 1}	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	{addButtonText: Add a gastrointestinal assessment}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: table_form}	eCell	eCell	{elementKey: table}	{pN: 17}	{fN: 1}	{gN: }	{sgN: }	eCell	{formOption: transpose}	eCell	eCell	eCell	{addButtonText: Add a gastrointestinal assessment}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 17}	{fN: 1}	{gN: 1}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: record_header}	eCell	eCell	eCell	{pN: 17}	{fN: 1}	{gN: 1}	{sgN: }	eCell	eCell	eCell	{tableColumn: 1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{pN: 17}	{fN: 1}	{gN: 2}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell


### PR DESCRIPTION
When the instructor views student data and the "develop content" flag was on the instructor would be able to edit the student's work.  Now, the action of viewing student data disables the "develop content" flag.
The seed editor now sees a developer context banner in the EHR.
Transpose tables now work. NOTE: the way to indicate a table is transposed is via the INPUTs sheet. Add 'transpose' to the 'formOptions' for the 'table_form'.  See Current Visit -1 for an example.