### PR TITLE
Validate directive -- use in assignment/seed dialogs

### DIFF
--- a/client/src/app/components/AppDialogShell.vue
+++ b/client/src/app/components/AppDialogShell.vue
@@ -19,7 +19,7 @@
             ui-button(v-on:buttonClicked="$emit('cancel')", v-bind:secondary="true")
               slot(name="cancel-button") {{ cancelButtonLabel }}
             div(class="dialog-footer-button-space", v-show="useSave")
-            ui-button(v-on:buttonClicked="$emit('save')", v-show="useSave")
+            ui-button(v-on:buttonClicked="$emit('save')", v-show="useSave", :disabled="disableSave")
               slot(name="save-button") {{ saveButtonLabel }}
 </template>
 
@@ -35,6 +35,7 @@ export default {
   props: {
     isModal: { type: Boolean, default: false },
     useSave: { type: Boolean, default: true },
+    disableSave: { type: Boolean, default: false },
     saveButtonLabel: {
       type: String,
       default: 'Save'

--- a/client/src/app/ui/UiButton.vue
+++ b/client/src/app/ui/UiButton.vue
@@ -1,19 +1,20 @@
-<template>
-  <button v-on:click="buttonClicked" v-bind:class="classObject"><slot /></button>
+<template lang="pug">
+  button(v-on:click="buttonClicked", v-bind:class="classObject", :disabled="disabled")
+    slot
 </template>
 
 <script>
 export default {
-  name: 'UiButton',
   props: {
     value: { type: String },
     secondary: {
       type: Boolean
-    }
+    },
+    disabled: { type: Boolean, default: false },
   },
   computed: {
     classObject: function () {
-      var def = {
+      let def = {
         button: true
       }
       if (this.secondary) {

--- a/client/src/directives/validate.js
+++ b/client/src/directives/validate.js
@@ -1,0 +1,97 @@
+/*
+ * Vue directive to validate a form field.
+ *
+ * Usage:
+  1. Include this directive you your Vue main.js.
+    import Vue from 'vue'
+    import validate from './directives/validate'
+    Vue.directive('validate', validate)
+  2. In a component, add directive to any input field. For example
+    input(v-model="name", v-validate="nameValidate")
+  3. In the component, provide the validation computed property
+    computed: {
+    nameValidate () {
+      return this.name.trim() ? undefined : 'Name is required'
+    },
+ *
+ * The validator needs to return undefined when the field is valid and a text message when invalid.
+ *
+ * When the user enters the field the onFocus event will fire.  Now as the user makes updates the validation will happen. Validation also happens when the user leaves the field with the onblur event.  Validtion checks to see if the field is valid which is indicated if the text message is empty.  If a validation message exists then it will be displayed in a div element appended to the parent of the field element.  When the user enters valid content the form field becomes valid this div will be removed.
+ *
+ * Note that update will run whenever the nameValidate property changes. This directive stores the text message, if present, in the DOM dataset ready to be used when the _onBlur event is fired.
+
+ * For more about Vue custom directives see https://vuejs.org/v2/guide/custom-directive.html
+ */
+const INVALID_CLASS = 'is-invalid'
+
+export default {
+  bind (el, binding) {
+    el.addEventListener('blur', _onBlur)
+    el.addEventListener('focus', _onFocus)
+    // clear on bind because the element may be reused from a previous invocation of a dialog
+    _clear (el)
+    el.dataset.focus = false
+  },
+  update (el, binding) {
+    _onUpdate(el, binding)
+  },
+  unbind (el) {
+    el.removeEventListener('blur', _onBlur)
+    el.removeEventListener('focus', _onFocus)
+  }
+}
+
+function _onUpdate (el, binding) {
+  delete el.dataset.text
+  _clear(el)
+  if ( binding.value ) {
+    el.dataset.text = binding.value
+    if (el.dataset.focus ==='true') {
+      _check(el)
+    }
+  }
+}
+
+function _onFocus (event){
+  event.target.dataset.focus = true
+}
+
+function _onBlur (event){
+  const el = event.target
+  el.dataset.focus = false
+  _check(el)
+}
+
+function _clear (el) {
+  el.classList.remove(INVALID_CLASS)
+  _removeChild(el)
+}
+
+function _check(el) {
+  const invalid = !!el.dataset.text
+  _clear(el)
+  if (invalid) {
+    el.classList.add(INVALID_CLASS)
+    _addChild(el)
+  }
+}
+function _addChild (el){
+  let after = document.createElement('div')
+  after.style.color = 'red'
+  after.innerHTML = el.dataset.text
+  after.dataset.velem = true
+  el.parentElement.appendChild(after)
+}
+
+function _removeChild (el) {
+  if (el.parentElement) {
+    let children = el.parentElement.childNodes
+    for (let i = 0; i < children.length; i++) {
+      let child = children[i]
+      if (child.dataset.velem) {
+        el.parentElement.removeChild(child)
+        break
+      }
+    }
+  }
+}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ import insideLayout from './inside/layout/LayoutEhr.vue'
 import dragDirective from './directives/drag-directive'
 import resizeDirective from './directives/resize-directive'
 import textToHtml from './directives/text-to-html'
+import validate from './directives/validate'
 
 /*
 Import the global style sheet
@@ -57,6 +58,7 @@ Vue.component('inside-layout', insideLayout)
 Vue.directive('dragged', dragDirective)
 Vue.directive('resized', resizeDirective)
 Vue.directive('textToHtml', textToHtml) // used as text-to-html attribute
+Vue.directive('validate', validate)
 
 /*
 Create the root Vue component.

--- a/client/src/outside/components/Activity.vue
+++ b/client/src/outside/components/Activity.vue
@@ -12,7 +12,7 @@
             td Assignment name:
             td
               ui-link(:name="'assignments'", :params="{assignmentId: assignment._id}")
-              span(v-on:click="switchAssignment")  {{ assignment.name }}
+                span(v-on:click="switchAssignment")  {{ assignment.name }}
           tr
             td Assignment description:
             td


### PR DESCRIPTION
Create a validate form field directive that can be applied to any form field. It will trigger when the user enters and edits or enters and then leaves (blur) the form field. Also disable the assignment dialog's save button until the form is valid.