### PR TITLE
Selects now have keys and values

### DIFF
--- a/client/src/inside/components/page/EhrElementForm.vue
+++ b/client/src/inside/components/page/EhrElementForm.vue
@@ -35,7 +35,7 @@
       div(class="select")
         select(v-bind:name="elementKey", v-bind:disabled="disabled", v-model="inputVal")
           option(value="")
-          option(v-for="option in options", :key="option.text", v-bind:value="option.text") {{ option.text}}
+          option(v-for="option in options", :key="option.key", v-bind:value="option.key") {{ option.text}}
 
     div(v-else-if="isType('text')", class="text_input_wrapper")
       ehr-page-form-label(:element="element", css="text_label")

--- a/client/src/inside/defs-grid/current-visit-1.js
+++ b/client/src/inside/defs-grid/current-visit-1.js
@@ -35,24 +35,31 @@ export default function () {
           mandatory: true,
           options: [
             {
+              key: 'Admission in progress',
               text: 'Admission in progress'
             },
             {
+              key: 'Admitted',
               text: 'Admitted'
             },
             {
+              key: 'Inpatient',
               text: 'Inpatient'
             },
             {
+              key: 'Outpatient',
               text: 'Outpatient'
             },
             {
+              key: 'Surgical day care',
               text: 'Surgical day care'
             },
             {
+              key: 'Discharge pending',
               text: 'Discharge pending'
             },
             {
+              key: 'Discharged',
               text: 'Discharged'
             }
           ],
@@ -329,12 +336,15 @@ export default function () {
           label: 'Patient position',
           options: [
             {
+              key: 'Supine',
               text: 'Supine'
             },
             {
+              key: 'Sitting',
               text: 'Sitting'
             },
             {
+              key: 'Standing',
               text: 'Standing'
             }
           ],
@@ -362,15 +372,19 @@ export default function () {
           label: 'Temperature source',
           options: [
             {
+              key: 'Oral',
               text: 'Oral'
             },
             {
+              key: 'Axilla',
               text: 'Axilla'
             },
             {
+              key: 'Rectal',
               text: 'Rectal'
             },
             {
+              key: 'Tympanic',
               text: 'Tympanic'
             }
           ],
@@ -393,6 +407,7 @@ export default function () {
           label: 'Pulse site',
           options: [
             {
+              key: 'Peripheral',
               text: 'Peripheral'
             }
           ],
@@ -418,9 +433,11 @@ export default function () {
           label: 'Pulse rhythm',
           options: [
             {
+              key: 'Regular',
               text: 'Regular'
             },
             {
+              key: 'Irregular',
               text: 'Irregular'
             }
           ],
@@ -469,18 +486,23 @@ export default function () {
           label: 'Oxygen mode',
           options: [
             {
+              key: 'Room air',
               text: 'Room air'
             },
             {
+              key: 'Nasal prongs',
               text: 'Nasal prongs'
             },
             {
+              key: 'Simple face mask',
               text: 'Simple face mask'
             },
             {
+              key: 'Rebreathing face mask',
               text: 'Rebreathing face mask'
             },
             {
+              key: 'Optiflow',
               text: 'Optiflow'
             }
           ],
@@ -856,24 +878,31 @@ export default function () {
           label: 'Status',
           options: [
             {
+              key: 'Alert',
               text: 'Alert'
             },
             {
+              key: 'Oriented',
               text: 'Oriented'
             },
             {
+              key: 'Confused',
               text: 'Confused'
             },
             {
+              key: 'Drowsy',
               text: 'Drowsy'
             },
             {
+              key: 'Unresponsive',
               text: 'Unresponsive'
             },
             {
+              key: 'Dizziness',
               text: 'Dizziness'
             },
             {
+              key: 'Blurred vision',
               text: 'Blurred vision'
             }
           ],
@@ -890,18 +919,23 @@ export default function () {
           label: 'Eye opening',
           options: [
             {
+              key: '0 = Non testable',
               text: '0 = Non testable'
             },
             {
+              key: '1 = None',
               text: '1 = None'
             },
             {
+              key: '2 = To pressure',
               text: '2 = To pressure'
             },
             {
+              key: '3 = To sound',
               text: '3 = To sound'
             },
             {
+              key: '4 = Spontaneous',
               text: '4 = Spontaneous'
             }
           ],
@@ -918,21 +952,27 @@ export default function () {
           label: 'Verbal response',
           options: [
             {
+              key: '0 = Non testable',
               text: '0 = Non testable'
             },
             {
+              key: '1 = None',
               text: '1 = None'
             },
             {
+              key: '2 = Sounds',
               text: '2 = Sounds'
             },
             {
+              key: '3 = Words',
               text: '3 = Words'
             },
             {
+              key: '4 = Confused',
               text: '4 = Confused'
             },
             {
+              key: '5 = Oriented',
               text: '5 = Oriented'
             }
           ],
@@ -949,24 +989,31 @@ export default function () {
           label: 'Best motor response',
           options: [
             {
+              key: '0 = Non testable',
               text: '0 = Non testable'
             },
             {
+              key: '1 = None',
               text: '1 = None'
             },
             {
+              key: '2 = Extension',
               text: '2 = Extension'
             },
             {
+              key: '3 = Normal flexion',
               text: '3 = Normal flexion'
             },
             {
+              key: '4 = Abnormal flexion',
               text: '4 = Abnormal flexion'
             },
             {
+              key: '5 = Localising',
               text: '5 = Localising'
             },
             {
+              key: '6 = Obeys commands',
               text: '6 = Obeys commands'
             }
           ],
@@ -984,6 +1031,7 @@ export default function () {
           label: 'Glasgow Coma Scale',
           options: [
             {
+              key: '=14+14+14',
               text: '=14+14+14'
             }
           ],
@@ -1000,12 +1048,15 @@ export default function () {
           label: 'Loss of conciousness',
           options: [
             {
+              key: 'No',
               text: 'No'
             },
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'Unknown',
               text: 'Unknown'
             }
           ],
@@ -1032,27 +1083,35 @@ export default function () {
           label: 'Left pupil size',
           options: [
             {
+              key: '1',
               text: '1'
             },
             {
+              key: '2',
               text: '2'
             },
             {
+              key: '3',
               text: '3'
             },
             {
+              key: '4',
               text: '4'
             },
             {
+              key: '5',
               text: '5'
             },
             {
+              key: '6',
               text: '6'
             },
             {
+              key: '7',
               text: '7'
             },
             {
+              key: '8',
               text: '8'
             }
           ],
@@ -1068,12 +1127,15 @@ export default function () {
           label: 'Left pupil response to light',
           options: [
             {
+              key: 'Brisk',
               text: 'Brisk'
             },
             {
+              key: 'Sluggish',
               text: 'Sluggish'
             },
             {
+              key: 'Fixed',
               text: 'Fixed'
             }
           ],
@@ -1096,27 +1158,35 @@ export default function () {
           label: 'Right pupil size',
           options: [
             {
+              key: '1',
               text: '1'
             },
             {
+              key: '2',
               text: '2'
             },
             {
+              key: '3',
               text: '3'
             },
             {
+              key: '4',
               text: '4'
             },
             {
+              key: '5',
               text: '5'
             },
             {
+              key: '6',
               text: '6'
             },
             {
+              key: '7',
               text: '7'
             },
             {
+              key: '8',
               text: '8'
             }
           ],
@@ -1132,12 +1202,15 @@ export default function () {
           label: 'Right pupil response to light',
           options: [
             {
+              key: 'Brisk',
               text: 'Brisk'
             },
             {
+              key: 'Sluggish',
               text: 'Sluggish'
             },
             {
+              key: 'Fixed',
               text: 'Fixed'
             }
           ],
@@ -1153,9 +1226,11 @@ export default function () {
           label: 'Both pupils',
           options: [
             {
+              key: 'Equal',
               text: 'Equal'
             },
             {
+              key: 'Unequal',
               text: 'Unequal'
             }
           ],
@@ -1190,15 +1265,19 @@ export default function () {
           label: 'Level of conciousness',
           options: [
             {
+              key: '0 = Alert; keenly responsive',
               text: '0 = Alert; keenly responsive'
             },
             {
+              key: '1 = Not alert; but arousable by minor stimulation',
               text: '1 = Not alert; but arousable by minor stimulation'
             },
             {
+              key: '2 = Not alert; requires repeated stimulation',
               text: '2 = Not alert; requires repeated stimulation'
             },
             {
+              key: '3 = Unresponsive or responds only with reflex',
               text: '3 = Unresponsive or responds only with reflex'
             }
           ],
@@ -1214,12 +1293,15 @@ export default function () {
           label: 'Level of conciousness questions',
           options: [
             {
+              key: '0 = Answers two questions correctly',
               text: '0 = Answers two questions correctly'
             },
             {
+              key: '1 = Answers one question correctly',
               text: '1 = Answers one question correctly'
             },
             {
+              key: '2 = Answers neither question correctly',
               text: '2 = Answers neither question correctly'
             }
           ],
@@ -1235,12 +1317,15 @@ export default function () {
           label: 'Level of conciousness commands',
           options: [
             {
+              key: '0 = Performs both tasks correctly',
               text: '0 = Performs both tasks correctly'
             },
             {
+              key: '1 = Performs one task correctly',
               text: '1 = Performs one task correctly'
             },
             {
+              key: '2 = Performs neither task correctly',
               text: '2 = Performs neither task correctly'
             }
           ],
@@ -1257,18 +1342,23 @@ export default function () {
           label: 'Motor - left arm',
           options: [
             {
+              key: '0 = No drift',
               text: '0 = No drift'
             },
             {
+              key: '1 = Drift',
               text: '1 = Drift'
             },
             {
+              key: '2 = Some effort against gravity',
               text: '2 = Some effort against gravity'
             },
             {
+              key: '3 = No effort against gravity; limb falls',
               text: '3 = No effort against gravity; limb falls'
             },
             {
+              key: '4 = No movement',
               text: '4 = No movement'
             }
           ],
@@ -1284,18 +1374,23 @@ export default function () {
           label: 'Motor - right arm',
           options: [
             {
+              key: '0 = No drift',
               text: '0 = No drift'
             },
             {
+              key: '1 = Drift',
               text: '1 = Drift'
             },
             {
+              key: '2 = Some effort against gravity',
               text: '2 = Some effort against gravity'
             },
             {
+              key: '3 = No effort against gravity; limb falls',
               text: '3 = No effort against gravity; limb falls'
             },
             {
+              key: '4 = No movement',
               text: '4 = No movement'
             }
           ],
@@ -1317,18 +1412,23 @@ export default function () {
           label: 'Motor - left leg',
           options: [
             {
+              key: '0 = No drift',
               text: '0 = No drift'
             },
             {
+              key: '1 = Drift',
               text: '1 = Drift'
             },
             {
+              key: '2 = Some effort against gravity',
               text: '2 = Some effort against gravity'
             },
             {
+              key: '3 = No effort against gravity',
               text: '3 = No effort against gravity'
             },
             {
+              key: '4 = No movement',
               text: '4 = No movement'
             }
           ],
@@ -1344,18 +1444,23 @@ export default function () {
           label: 'Motor - right leg',
           options: [
             {
+              key: '0 = No drift',
               text: '0 = No drift'
             },
             {
+              key: '1 = Drift',
               text: '1 = Drift'
             },
             {
+              key: '2 = Some effort against gravity',
               text: '2 = Some effort against gravity'
             },
             {
+              key: '3 = No effort against gravity',
               text: '3 = No effort against gravity'
             },
             {
+              key: '4 = No movement',
               text: '4 = No movement'
             }
           ],
@@ -1371,12 +1476,15 @@ export default function () {
           label: 'Limb ataxia',
           options: [
             {
+              key: '0 = Absent',
               text: '0 = Absent'
             },
             {
+              key: '1 = Present in one limb',
               text: '1 = Present in one limb'
             },
             {
+              key: '2 = Present in two limbs',
               text: '2 = Present in two limbs'
             }
           ],
@@ -1393,12 +1501,15 @@ export default function () {
           label: 'Best gaze',
           options: [
             {
+              key: '0 = Normal',
               text: '0 = Normal'
             },
             {
+              key: '1 = Partial gaze palsy',
               text: '1 = Partial gaze palsy'
             },
             {
+              key: '2 = Forced deviation',
               text: '2 = Forced deviation'
             }
           ],
@@ -1414,15 +1525,19 @@ export default function () {
           label: 'Visual',
           options: [
             {
+              key: '0 = No visual loss',
               text: '0 = No visual loss'
             },
             {
+              key: '1 = Partial hemianopia',
               text: '1 = Partial hemianopia'
             },
             {
+              key: '2 = Partial paralysis',
               text: '2 = Partial paralysis'
             },
             {
+              key: '3 = Complete paralysis of one or both sides',
               text: '3 = Complete paralysis of one or both sides'
             }
           ],
@@ -1438,15 +1553,19 @@ export default function () {
           label: 'Facial palsy',
           options: [
             {
+              key: '0 = Normal symmetric movements',
               text: '0 = Normal symmetric movements'
             },
             {
+              key: '1 = Minor paralysis',
               text: '1 = Minor paralysis'
             },
             {
+              key: '2 = Partial paralysis',
               text: '2 = Partial paralysis'
             },
             {
+              key: '3 = Complete paralysis of one or both sides',
               text: '3 = Complete paralysis of one or both sides'
             }
           ],
@@ -1462,12 +1581,15 @@ export default function () {
           label: 'Sensory',
           options: [
             {
+              key: '0 = Normal; no sensory loss',
               text: '0 = Normal; no sensory loss'
             },
             {
+              key: '1 = Mild-to-moderate sensory loss',
               text: '1 = Mild-to-moderate sensory loss'
             },
             {
+              key: '2 = Severe to total sensory loss',
               text: '2 = Severe to total sensory loss'
             }
           ],
@@ -1483,15 +1605,19 @@ export default function () {
           label: 'Best language',
           options: [
             {
+              key: '0 = No aphasia; normal',
               text: '0 = No aphasia; normal'
             },
             {
+              key: '1 = Mild to moderate aphasia',
               text: '1 = Mild to moderate aphasia'
             },
             {
+              key: '2 = Severe aphasia',
               text: '2 = Severe aphasia'
             },
             {
+              key: '3 = Mute, global aphasia',
               text: '3 = Mute, global aphasia'
             }
           ],
@@ -1507,12 +1633,15 @@ export default function () {
           label: 'Dysarthria',
           options: [
             {
+              key: '0 = Normal',
               text: '0 = Normal'
             },
             {
+              key: '1 = Mild to moderate',
               text: '1 = Mild to moderate'
             },
             {
+              key: '2 = Severe dysarthria',
               text: '2 = Severe dysarthria'
             }
           ],
@@ -1528,12 +1657,15 @@ export default function () {
           label: 'Extinction and inattention',
           options: [
             {
+              key: '0 = No abnormality',
               text: '0 = No abnormality'
             },
             {
+              key: '1 = Visual, tactile, auditory, spatial, or personal inattention',
               text: '1 = Visual, tactile, auditory, spatial, or personal inattention'
             },
             {
+              key: '2 = Profound hemi-inattention or extinction',
               text: '2 = Profound hemi-inattention or extinction'
             }
           ],
@@ -1962,15 +2094,19 @@ export default function () {
           label: 'Airway',
           options: [
             {
+              key: 'Patent',
               text: 'Patent'
             },
             {
+              key: 'Obstructed',
               text: 'Obstructed'
             },
             {
+              key: 'Oral endotracheal tube',
               text: 'Oral endotracheal tube'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -2006,18 +2142,23 @@ export default function () {
           label: 'Left upper lung',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Wheeze',
               text: 'Wheeze'
             },
             {
+              key: 'Crackles',
               text: 'Crackles'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             },
             {
+              key: 'Decreased',
               text: 'Decreased'
             }
           ],
@@ -2033,18 +2174,23 @@ export default function () {
           label: 'Right upper lung',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Wheeze',
               text: 'Wheeze'
             },
             {
+              key: 'Crackles',
               text: 'Crackles'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             },
             {
+              key: 'Decreased',
               text: 'Decreased'
             }
           ],
@@ -2074,18 +2220,23 @@ export default function () {
           label: 'Right middle lung',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Wheeze',
               text: 'Wheeze'
             },
             {
+              key: 'Crackles',
               text: 'Crackles'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             },
             {
+              key: 'Decreased',
               text: 'Decreased'
             }
           ],
@@ -2108,18 +2259,23 @@ export default function () {
           label: 'Left lower lung',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Wheeze',
               text: 'Wheeze'
             },
             {
+              key: 'Crackles',
               text: 'Crackles'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             },
             {
+              key: 'Decreased',
               text: 'Decreased'
             }
           ],
@@ -2135,18 +2291,23 @@ export default function () {
           label: 'Right lower lung',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Wheeze',
               text: 'Wheeze'
             },
             {
+              key: 'Crackles',
               text: 'Crackles'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             },
             {
+              key: 'Decreased',
               text: 'Decreased'
             }
           ],
@@ -2170,12 +2331,15 @@ export default function () {
           label: 'Respiratory rhythm',
           options: [
             {
+              key: 'Regular',
               text: 'Regular'
             },
             {
+              key: 'Irregular',
               text: 'Irregular'
             },
             {
+              key: 'Paradoxical',
               text: 'Paradoxical'
             }
           ],
@@ -2191,12 +2355,15 @@ export default function () {
           label: 'Respiratory depth',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Shallow',
               text: 'Shallow'
             },
             {
+              key: 'Deep',
               text: 'Deep'
             }
           ],
@@ -2219,12 +2386,15 @@ export default function () {
           label: 'Cough',
           options: [
             {
+              key: 'No',
               text: 'No'
             },
             {
+              key: 'Nonproductive',
               text: 'Nonproductive'
             },
             {
+              key: 'Productive',
               text: 'Productive'
             }
           ],
@@ -2240,27 +2410,35 @@ export default function () {
           label: 'Sputum colour',
           options: [
             {
+              key: 'Mucoid',
               text: 'Mucoid'
             },
             {
+              key: 'Purulent',
               text: 'Purulent'
             },
             {
+              key: 'Yellow-green',
               text: 'Yellow-green'
             },
             {
+              key: 'Rust-coloured',
               text: 'Rust-coloured'
             },
             {
+              key: 'Pink, blood tinged',
               text: 'Pink, blood tinged'
             },
             {
+              key: 'Pink, frothy',
               text: 'Pink, frothy'
             },
             {
+              key: 'Profuse, colourless',
               text: 'Profuse, colourless'
             },
             {
+              key: 'Bloody',
               text: 'Bloody'
             }
           ],
@@ -2541,18 +2719,23 @@ export default function () {
           label: 'Pulse',
           options: [
             {
+              key: 'Regular',
               text: 'Regular'
             },
             {
+              key: 'Irregular',
               text: 'Irregular'
             },
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Weak',
               text: 'Weak'
             },
             {
+              key: 'Bounding',
               text: 'Bounding'
             }
           ],
@@ -2568,21 +2751,27 @@ export default function () {
           label: 'Skin appearance',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Pale',
               text: 'Pale'
             },
             {
+              key: 'Mottled',
               text: 'Mottled'
             },
             {
+              key: 'Cyanotic',
               text: 'Cyanotic'
             },
             {
+              key: 'Flushed',
               text: 'Flushed'
             },
             {
+              key: 'Jaundiced',
               text: 'Jaundiced'
             }
           ],
@@ -2647,9 +2836,11 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Normal < 3 seconds',
               text: 'Normal < 3 seconds'
             },
             {
+              key: 'Delayed > 3 seconds',
               text: 'Delayed > 3 seconds'
             }
           ],
@@ -2666,12 +2857,15 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Warm',
               text: 'Warm'
             },
             {
+              key: 'Cool',
               text: 'Cool'
             },
             {
+              key: 'Hot',
               text: 'Hot'
             }
           ],
@@ -2688,18 +2882,23 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'No',
               text: 'No'
             },
             {
+              key: 'Ankle',
               text: 'Ankle'
             },
             {
+              key: 'Pedal',
               text: 'Pedal'
             },
             {
+              key: 'Sacral',
               text: 'Sacral'
             },
             {
+              key: 'Pitting',
               text: 'Pitting'
             }
           ],
@@ -2716,9 +2915,11 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Pink',
               text: 'Pink'
             },
             {
+              key: 'Cyanotic',
               text: 'Cyanotic'
             }
           ],
@@ -2743,9 +2944,11 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Normal < 3 seconds',
               text: 'Normal < 3 seconds'
             },
             {
+              key: 'Delayed > 3 seconds',
               text: 'Delayed > 3 seconds'
             }
           ],
@@ -2762,12 +2965,15 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Warm',
               text: 'Warm'
             },
             {
+              key: 'Cool',
               text: 'Cool'
             },
             {
+              key: 'Hot',
               text: 'Hot'
             }
           ],
@@ -2784,18 +2990,23 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'No',
               text: 'No'
             },
             {
+              key: 'Ankle',
               text: 'Ankle'
             },
             {
+              key: 'Pedal',
               text: 'Pedal'
             },
             {
+              key: 'Sacral',
               text: 'Sacral'
             },
             {
+              key: 'Pitting',
               text: 'Pitting'
             }
           ],
@@ -2812,9 +3023,11 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Pink',
               text: 'Pink'
             },
             {
+              key: 'Cyanotic',
               text: 'Cyanotic'
             }
           ],
@@ -2839,9 +3052,11 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Normal < 3 seconds',
               text: 'Normal < 3 seconds'
             },
             {
+              key: 'Delayed > 3 seconds',
               text: 'Delayed > 3 seconds'
             }
           ],
@@ -2858,12 +3073,15 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Warm',
               text: 'Warm'
             },
             {
+              key: 'Cool',
               text: 'Cool'
             },
             {
+              key: 'Hot',
               text: 'Hot'
             }
           ],
@@ -2880,18 +3098,23 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'No',
               text: 'No'
             },
             {
+              key: 'Ankle',
               text: 'Ankle'
             },
             {
+              key: 'Pedal',
               text: 'Pedal'
             },
             {
+              key: 'Sacral',
               text: 'Sacral'
             },
             {
+              key: 'Pitting',
               text: 'Pitting'
             }
           ],
@@ -2908,9 +3131,11 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Pink',
               text: 'Pink'
             },
             {
+              key: 'Cyanotic',
               text: 'Cyanotic'
             }
           ],
@@ -2935,9 +3160,11 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Normal < 3 seconds',
               text: 'Normal < 3 seconds'
             },
             {
+              key: 'Delayed > 3 seconds',
               text: 'Delayed > 3 seconds'
             }
           ],
@@ -2954,12 +3181,15 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Warm',
               text: 'Warm'
             },
             {
+              key: 'Cool',
               text: 'Cool'
             },
             {
+              key: 'Hot',
               text: 'Hot'
             }
           ],
@@ -2976,18 +3206,23 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'No',
               text: 'No'
             },
             {
+              key: 'Ankle',
               text: 'Ankle'
             },
             {
+              key: 'Pedal',
               text: 'Pedal'
             },
             {
+              key: 'Sacral',
               text: 'Sacral'
             },
             {
+              key: 'Pitting',
               text: 'Pitting'
             }
           ],
@@ -3004,9 +3239,11 @@ export default function () {
           inputType: 'select',
           options: [
             {
+              key: 'Pink',
               text: 'Pink'
             },
             {
+              key: 'Cyanotic',
               text: 'Cyanotic'
             }
           ],
@@ -3333,18 +3570,23 @@ export default function () {
           label: 'Bowel',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Constipation',
               text: 'Constipation'
             },
             {
+              key: 'Diarrhea',
               text: 'Diarrhea'
             },
             {
+              key: 'Melena',
               text: 'Melena'
             },
             {
+              key: 'Incontinent',
               text: 'Incontinent'
             }
           ],
@@ -3359,24 +3601,31 @@ export default function () {
           label: 'Bowel sounds',
           options: [
             {
+              key: 'None',
               text: 'None'
             },
             {
+              key: 'LUQ',
               text: 'LUQ'
             },
             {
+              key: 'RUQ',
               text: 'RUQ'
             },
             {
+              key: 'LLQ',
               text: 'LLQ'
             },
             {
+              key: 'RLQ',
               text: 'RLQ'
             },
             {
+              key: 'Hypoactive',
               text: 'Hypoactive'
             },
             {
+              key: 'Hyperactive',
               text: 'Hyperactive'
             }
           ],
@@ -3391,21 +3640,27 @@ export default function () {
           label: 'Abdomen',
           options: [
             {
+              key: 'soft=Soft',
               text: 'soft=Soft'
             },
             {
+              key: 'tender=Tender',
               text: 'tender=Tender'
             },
             {
+              key: 'rigid=Rigid',
               text: 'rigid=Rigid'
             },
             {
+              key: 'guarding=Guarding',
               text: 'guarding=Guarding'
             },
             {
+              key: 'distended=Distended',
               text: 'distended=Distended'
             },
             {
+              key: 'scars=Scars',
               text: 'scars=Scars'
             }
           ],
@@ -3435,9 +3690,11 @@ export default function () {
           label: 'Abdominal pain',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -3475,12 +3732,15 @@ export default function () {
           label: 'Emesis present?',
           options: [
             {
+              key: 'None',
               text: 'None'
             },
             {
+              key: 'Nausea',
               text: 'Nausea'
             },
             {
+              key: 'Vomiting',
               text: 'Vomiting'
             }
           ],
@@ -3496,18 +3756,23 @@ export default function () {
           label: 'Emesis colour',
           options: [
             {
+              key: 'Greenish-yellow',
               text: 'Greenish-yellow'
             },
             {
+              key: 'Blood-tinged',
               text: 'Blood-tinged'
             },
             {
+              key: 'Bright red',
               text: 'Bright red'
             },
             {
+              key: 'Dark red',
               text: 'Dark red'
             },
             {
+              key: 'Black',
               text: 'Black'
             }
           ],
@@ -3533,12 +3798,15 @@ export default function () {
           label: 'Approximate volume',
           options: [
             {
+              key: 'Small',
               text: 'Small'
             },
             {
+              key: 'Moderate',
               text: 'Moderate'
             },
             {
+              key: 'Large',
               text: 'Large'
             }
           ],
@@ -3555,9 +3823,11 @@ export default function () {
           label: 'Difficulty',
           options: [
             {
+              key: 'Regular',
               text: 'Regular'
             },
             {
+              key: 'Difficult',
               text: 'Difficult'
             }
           ],
@@ -3630,24 +3900,31 @@ export default function () {
           label: 'Stool colour',
           options: [
             {
+              key: 'Brown',
               text: 'Brown'
             },
             {
+              key: 'Green',
               text: 'Green'
             },
             {
+              key: 'Clay coloured',
               text: 'Clay coloured'
             },
             {
+              key: 'Yellow',
               text: 'Yellow'
             },
             {
+              key: 'Black',
               text: 'Black'
             },
             {
+              key: 'Bright red',
               text: 'Bright red'
             },
             {
+              key: 'Dark red',
               text: 'Dark red'
             }
           ],
@@ -3663,9 +3940,11 @@ export default function () {
           label: 'Description',
           options: [
             {
+              key: 'Runny',
               text: 'Runny'
             },
             {
+              key: 'Hard pellets',
               text: 'Hard pellets'
             }
           ],
@@ -3691,12 +3970,15 @@ export default function () {
           label: 'Source',
           options: [
             {
+              key: 'Observed',
               text: 'Observed'
             },
             {
+              key: 'As per patient observed',
               text: 'As per patient observed'
             },
             {
+              key: 'Not observed',
               text: 'Not observed'
             }
           ],

--- a/client/src/inside/defs-grid/current-visit-2.js
+++ b/client/src/inside/defs-grid/current-visit-2.js
@@ -50,27 +50,35 @@ export default function () {
           label: 'Urinary symptoms',
           options: [
             {
+              key: 'None',
               text: 'None'
             },
             {
+              key: 'Increased frequency',
               text: 'Increased frequency'
             },
             {
+              key: 'Dysuria',
               text: 'Dysuria'
             },
             {
+              key: 'Hermaturia',
               text: 'Hermaturia'
             },
             {
+              key: 'Oliguria',
               text: 'Oliguria'
             },
             {
+              key: 'Incontinence',
               text: 'Incontinence'
             },
             {
+              key: 'Retention',
               text: 'Retention'
             },
             {
+              key: 'Distention',
               text: 'Distention'
             }
           ],
@@ -109,18 +117,23 @@ export default function () {
           label: 'Urine colour',
           options: [
             {
+              key: 'Pale yellow',
               text: 'Pale yellow'
             },
             {
+              key: 'Dark yellow',
               text: 'Dark yellow'
             },
             {
+              key: 'Amber',
               text: 'Amber'
             },
             {
+              key: 'Red/blood',
               text: 'Red/blood'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -138,15 +151,19 @@ export default function () {
           label: 'Urine consistency',
           options: [
             {
+              key: 'Clear',
               text: 'Clear'
             },
             {
+              key: 'Cloudy',
               text: 'Cloudy'
             },
             {
+              key: 'Foamy',
               text: 'Foamy'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -164,9 +181,11 @@ export default function () {
           label: 'Diaper',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -185,9 +204,11 @@ export default function () {
           label: 'Foley',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -236,9 +257,11 @@ export default function () {
           label: 'Pelvic pain',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -262,12 +285,15 @@ export default function () {
           label: 'Pelvic pain source',
           options: [
             {
+              key: 'Observed',
               text: 'Observed'
             },
             {
+              key: 'As per patient observed',
               text: 'As per patient observed'
             },
             {
+              key: 'Not observed',
               text: 'Not observed'
             }
           ],
@@ -291,9 +317,11 @@ export default function () {
           label: 'Discharge',
           options: [
             {
+              key: 'Discharge',
               text: 'Discharge'
             },
             {
+              key: 'Bleeding',
               text: 'Bleeding'
             }
           ],
@@ -331,12 +359,15 @@ export default function () {
           label: 'Pregnant',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             },
             {
+              key: 'Unknown',
               text: 'Unknown'
             }
           ],
@@ -386,7 +417,7 @@ export default function () {
           fqn: 'genitourinary.comments'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -717,9 +748,11 @@ export default function () {
           label: 'Swelling',
           options: [
             {
+              key: 'Present',
               text: 'Present'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             }
           ],
@@ -735,9 +768,11 @@ export default function () {
           label: 'Pain',
           options: [
             {
+              key: 'Present',
               text: 'Present'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             }
           ],
@@ -753,9 +788,11 @@ export default function () {
           label: 'Deformity',
           options: [
             {
+              key: 'Present',
               text: 'Present'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             }
           ],
@@ -771,12 +808,15 @@ export default function () {
           label: 'Movement',
           options: [
             {
+              key: 'Normal',
               text: 'Normal'
             },
             {
+              key: 'Decreased',
               text: 'Decreased'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             }
           ],
@@ -792,12 +832,15 @@ export default function () {
           label: 'Sensation',
           options: [
             {
+              key: 'Present',
               text: 'Present'
             },
             {
+              key: 'Absent',
               text: 'Absent'
             },
             {
+              key: 'Numb',
               text: 'Numb'
             }
           ],
@@ -813,18 +856,23 @@ export default function () {
           label: 'Pulse',
           options: [
             {
+              key: 'Absent',
               text: 'Absent'
             },
             {
+              key: 'Weak',
               text: 'Weak'
             },
             {
+              key: 'Moderate',
               text: 'Moderate'
             },
             {
+              key: 'Strong',
               text: 'Strong'
             },
             {
+              key: 'Bounding',
               text: 'Bounding'
             }
           ],
@@ -840,12 +888,15 @@ export default function () {
           label: 'Colour',
           options: [
             {
+              key: 'Flesh',
               text: 'Flesh'
             },
             {
+              key: 'Pale',
               text: 'Pale'
             },
             {
+              key: 'Cynanotic',
               text: 'Cynanotic'
             }
           ],
@@ -862,12 +913,15 @@ export default function () {
           label: 'Temp',
           options: [
             {
+              key: 'Hot',
               text: 'Hot'
             },
             {
+              key: 'Warm',
               text: 'Warm'
             },
             {
+              key: 'Cold',
               text: 'Cold'
             }
           ],
@@ -876,10 +930,10 @@ export default function () {
           fqn: 'musculoskeletal.temp'
         },
         {
-          elementKey: 'spacer5',
+          elementKey: 'spacer72',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'musculoskeletal.spacer5'
+          fqn: 'musculoskeletal.spacer72'
         },
         {
           elementKey: 'useOfAmbulatoryAid',
@@ -890,9 +944,11 @@ export default function () {
           label: 'Use of ambulatory aid',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -909,21 +965,27 @@ export default function () {
           label: 'Type',
           options: [
             {
+              key: 'Walker',
               text: 'Walker'
             },
             {
+              key: 'Cane',
               text: 'Cane'
             },
             {
+              key: 'One crutch',
               text: 'One crutch'
             },
             {
+              key: 'Two crutches',
               text: 'Two crutches'
             },
             {
+              key: 'Wheelchair',
               text: 'Wheelchair'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -944,7 +1006,7 @@ export default function () {
           fqn: 'musculoskeletal.comments'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -1068,7 +1130,7 @@ export default function () {
                   'pulse',
                   'colour',
                   'temp',
-                  'spacer5',
+                  'spacer72',
                   'useOfAmbulatoryAid',
                   'type'
                 ]
@@ -1314,7 +1376,7 @@ export default function () {
           fqn: 'pain.comments'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -1588,12 +1650,15 @@ export default function () {
           label: 'From our experience in the hospital, we know that domestic violence can be a problem. Is this a factor in your life?',
           options: [
             {
+              key: 'Didn\'t ask',
               text: 'Didn\'t ask'
             },
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -1609,12 +1674,15 @@ export default function () {
           label: 'Would you like to speak to a social worker?',
           options: [
             {
+              key: 'Didn\'t ask',
               text: 'Didn\'t ask'
             },
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -1631,9 +1699,11 @@ export default function () {
           label: 'Hygiene',
           options: [
             {
+              key: 'Good',
               text: 'Good'
             },
             {
+              key: 'Requires attention',
               text: 'Requires attention'
             }
           ],
@@ -1660,24 +1730,31 @@ export default function () {
           label: 'Behaviour',
           options: [
             {
+              key: 'Calm',
               text: 'Calm'
             },
             {
+              key: 'Cooperative',
               text: 'Cooperative'
             },
             {
+              key: 'Agitated',
               text: 'Agitated'
             },
             {
+              key: 'Flat affect',
               text: 'Flat affect'
             },
             {
+              key: 'Threatening',
               text: 'Threatening'
             },
             {
+              key: 'Physically agressive',
               text: 'Physically agressive'
             },
             {
+              key: 'Uncommunicative',
               text: 'Uncommunicative'
             }
           ],
@@ -1694,15 +1771,19 @@ export default function () {
           label: 'Hallucinations',
           options: [
             {
+              key: 'None',
               text: 'None'
             },
             {
+              key: 'Visual',
               text: 'Visual'
             },
             {
+              key: 'Auditory',
               text: 'Auditory'
             },
             {
+              key: 'Olafactory',
               text: 'Olafactory'
             }
           ],
@@ -1719,12 +1800,15 @@ export default function () {
           label: 'Suicidal',
           options: [
             {
+              key: 'None',
               text: 'None'
             },
             {
+              key: 'Ideation',
               text: 'Ideation'
             },
             {
+              key: 'Attempt',
               text: 'Attempt'
             }
           ],
@@ -1740,9 +1824,11 @@ export default function () {
           label: 'Homicidal',
           options: [
             {
+              key: 'None',
               text: 'None'
             },
             {
+              key: 'Ideation',
               text: 'Ideation'
             }
           ],
@@ -1757,9 +1843,11 @@ export default function () {
           label: 'Speech',
           options: [
             {
+              key: 'Clear and coherent',
               text: 'Clear and coherent'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -1817,9 +1905,11 @@ export default function () {
           label: 'Patient restrained',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -1870,7 +1960,7 @@ export default function () {
           fqn: 'biopsychosocial.generalComments'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -2211,18 +2301,23 @@ export default function () {
           mandatory: '?',
           options: [
             {
+              key: 'Ordered',
               text: 'Ordered'
             },
             {
+              key: 'In process',
               text: 'In process'
             },
             {
+              key: 'Cancelled',
               text: 'Cancelled'
             },
             {
+              key: 'Completed',
               text: 'Completed'
             },
             {
+              key: 'Discontinued',
               text: 'Discontinued'
             }
           ],
@@ -2240,7 +2335,7 @@ export default function () {
           fqn: 'nonmedOrders.comment'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -2402,10 +2497,10 @@ export default function () {
           fqn: 'referrals.referralProfession'
         },
         {
-          elementKey: 'spacer34',
+          elementKey: 'spacer101',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'referrals.spacer34'
+          fqn: 'referrals.spacer101'
         },
         {
           elementKey: 'appointmentDate',
@@ -2435,9 +2530,11 @@ export default function () {
           label: 'Status',
           options: [
             {
+              key: 'Active',
               text: 'Active'
             },
             {
+              key: 'Discharged',
               text: 'Discharged'
             }
           ],
@@ -2446,7 +2543,7 @@ export default function () {
           fqn: 'referrals.status'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -2520,7 +2617,7 @@ export default function () {
                 gChildren: [
                   'referralName',
                   'referralProfession',
-                  'spacer34',
+                  'spacer101',
                   'appointmentDate',
                   'appointmentTime',
                   'status'
@@ -2601,10 +2698,10 @@ export default function () {
           fqn: 'labRequisitions.requisition'
         },
         {
-          elementKey: 'spacer37',
+          elementKey: 'spacer104',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'labRequisitions.spacer37'
+          fqn: 'labRequisitions.spacer104'
         },
         {
           elementKey: 'ordered',
@@ -2616,7 +2713,7 @@ export default function () {
           fqn: 'labRequisitions.ordered'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -2662,7 +2759,7 @@ export default function () {
                 gChildren: [
                   'requisition',
                   'requisition',
-                  'spacer37',
+                  'spacer104',
                   'ordered'
                 ]
               }
@@ -2758,30 +2855,39 @@ export default function () {
           label: 'Route',
           options: [
             {
+              key: 'Oral',
               text: 'Oral'
             },
             {
+              key: 'Sublingual',
               text: 'Sublingual'
             },
             {
+              key: 'Inhalation',
               text: 'Inhalation'
             },
             {
+              key: 'Nasal',
               text: 'Nasal'
             },
             {
+              key: 'Rectal',
               text: 'Rectal'
             },
             {
+              key: 'Vaginal',
               text: 'Vaginal'
             },
             {
+              key: 'Intravenous',
               text: 'Intravenous'
             },
             {
+              key: 'Intramuscular',
               text: 'Intramuscular'
             },
             {
+              key: 'Subcutaneous',
               text: 'Subcutaneous'
             }
           ],
@@ -2815,15 +2921,19 @@ export default function () {
           label: 'Administration',
           options: [
             {
+              key: 'Scheduled',
               text: 'Scheduled'
             },
             {
+              key: 'PRN (as needed)',
               text: 'PRN (as needed)'
             },
             {
+              key: 'Once',
               text: 'Once'
             },
             {
+              key: 'Stat',
               text: 'Stat'
             }
           ],
@@ -2838,12 +2948,15 @@ export default function () {
           label: 'Schedule time',
           options: [
             {
+              key: 'Morning',
               text: 'Morning'
             },
             {
+              key: 'Mid day',
               text: 'Mid day'
             },
             {
+              key: 'Bedtime',
               text: 'Bedtime'
             }
           ],
@@ -2879,7 +2992,7 @@ export default function () {
           fqn: 'medicationOrders.notes'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -3044,15 +3157,19 @@ export default function () {
           label: 'Medication status',
           options: [
             {
+              key: 'Active',
               text: 'Active'
             },
             {
+              key: 'Hold',
               text: 'Hold'
             },
             {
+              key: 'Discontinued',
               text: 'Discontinued'
             },
             {
+              key: '',
               text: ''
             }
           ],
@@ -3067,15 +3184,19 @@ export default function () {
           label: 'Administration status',
           options: [
             {
+              key: 'Administered',
               text: 'Administered'
             },
             {
+              key: 'Refused',
               text: 'Refused'
             },
             {
+              key: 'Missed',
               text: 'Missed'
             },
             {
+              key: 'Skipped',
               text: 'Skipped'
             }
           ],
@@ -3108,6 +3229,7 @@ export default function () {
           label: 'Today\'s plan',
           options: [
             {
+              key: '[Today\'s day] plan',
               text: '[Today\'s day] plan'
             }
           ],
@@ -3122,6 +3244,7 @@ export default function () {
           label: 'Today\'s given',
           options: [
             {
+              key: '[Today\'s day] given',
               text: '[Today\'s day] given'
             }
           ],
@@ -3159,7 +3282,7 @@ export default function () {
           helperHtml: '<p>Enter time delivered or say if not delivered.</p>'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -3289,34 +3412,41 @@ export default function () {
           label: 'Discharging physician/NP',
           options: [
             {
+              key: 'Dr. Notley',
               text: 'Dr. Notley'
             },
             {
+              key: 'Dr. Hunicutt',
               text: 'Dr. Hunicutt'
             },
             {
+              key: 'Dr. Lee',
               text: 'Dr. Lee'
             },
             {
+              key: 'Dr. Malik',
               text: 'Dr. Malik'
             },
             {
+              key: 'Dr. Ng',
               text: 'Dr. Ng'
             },
             {
+              key: 'Dr. Walker',
               text: 'Dr. Walker'
             },
             {
+              key: 'Dr. Brooks',
               text: 'Dr. Brooks'
             }
           ],
           fqn: 'dischargeSummary.dischargingPhysician/np'
         },
         {
-          elementKey: 'spacer44',
+          elementKey: 'spacer111',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'dischargeSummary.spacer44'
+          fqn: 'dischargeSummary.spacer111'
         },
         {
           elementKey: 'clinicalSummary',
@@ -3342,10 +3472,10 @@ export default function () {
           fqn: 'dischargeSummary.dischargeEducation'
         },
         {
-          elementKey: 'spacer46',
+          elementKey: 'spacer113',
           formIndex: '2',
           inputType: 'spacer',
-          fqn: 'dischargeSummary.spacer46'
+          fqn: 'dischargeSummary.spacer113'
         },
         {
           elementKey: 'dischargeDay',
@@ -3371,12 +3501,15 @@ export default function () {
           label: 'Discharged to',
           options: [
             {
+              key: 'Home',
               text: 'Home'
             },
             {
+              key: 'Expired',
               text: 'Expired'
             },
             {
+              key: 'Transferred',
               text: 'Transferred'
             }
           ],
@@ -3396,22 +3529,26 @@ export default function () {
           label: 'Leaving by',
           options: [
             {
+              key: 'Taxi',
               text: 'Taxi'
             },
             {
+              key: 'Family',
               text: 'Family'
             },
             {
+              key: 'Ambulance',
               text: 'Ambulance'
             },
             {
+              key: 'Walk out/wheelchair',
               text: 'Walk out/wheelchair'
             }
           ],
           fqn: 'dischargeSummary.leavingBy'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         pageForm: {
           elementKey: 'pageForm',
@@ -3423,7 +3560,7 @@ export default function () {
               gChildren: [
                 'admissionDay',
                 'dischargingPhysician/np',
-                'spacer44',
+                'spacer111',
                 'clinicalSummary'
               ]
             }
@@ -3439,7 +3576,7 @@ export default function () {
               gChildren: [
                 'dischargeDiagnosis',
                 'dischargeEducation',
-                'spacer46',
+                'spacer113',
                 'dischargeDay',
                 'dischargeTime',
                 'dischargedTo',
@@ -3466,19 +3603,22 @@ export default function () {
           label: 'Payment type',
           options: [
             {
+              key: 'MSP',
               text: 'MSP'
             },
             {
+              key: 'Third party',
               text: 'Third party'
             },
             {
+              key: 'Federal',
               text: 'Federal'
             }
           ],
           fqn: 'billing.paymentType'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         pageForm: {
           elementKey: 'pageForm',
@@ -3542,15 +3682,19 @@ export default function () {
           label: 'Wound label',
           options: [
             {
+              key: 'Wound A',
               text: 'Wound A'
             },
             {
+              key: 'Wound B',
               text: 'Wound B'
             },
             {
+              key: 'Wound C',
               text: 'Wound C'
             },
             {
+              key: 'Wound D',
               text: 'Wound D'
             }
           ],
@@ -3566,12 +3710,15 @@ export default function () {
           label: 'Goal of care',
           options: [
             {
+              key: 'To heal',
               text: 'To heal'
             },
             {
+              key: 'To maintain',
               text: 'To maintain'
             },
             {
+              key: 'To monitor/manage',
               text: 'To monitor/manage'
             }
           ],
@@ -3581,10 +3728,10 @@ export default function () {
           fqn: 'integumentaryAssessment.goalOfCare'
         },
         {
-          elementKey: 'spacer9',
+          elementKey: 'spacer76',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'integumentaryAssessment.spacer9'
+          fqn: 'integumentaryAssessment.spacer76'
         },
         {
           elementKey: 'woundLocation',
@@ -3613,24 +3760,31 @@ export default function () {
           label: 'Wound type/etiology',
           options: [
             {
+              key: 'Pressure injury',
               text: 'Pressure injury'
             },
             {
+              key: 'Venous ulcer',
               text: 'Venous ulcer'
             },
             {
+              key: 'Arterial ulcer',
               text: 'Arterial ulcer'
             },
             {
+              key: 'Diabetic ulcer',
               text: 'Diabetic ulcer'
             },
             {
+              key: 'Surgical secondary intent',
               text: 'Surgical secondary intent'
             },
             {
+              key: 'Skin tear',
               text: 'Skin tear'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -3646,21 +3800,27 @@ export default function () {
           label: 'Stage',
           options: [
             {
+              key: 'Stage 1',
               text: 'Stage 1'
             },
             {
+              key: 'Stage 2',
               text: 'Stage 2'
             },
             {
+              key: 'Stage 3',
               text: 'Stage 3'
             },
             {
+              key: 'Stage 4',
               text: 'Stage 4'
             },
             {
+              key: 'Stage X (unstageable)',
               text: 'Stage X (unstageable)'
             },
             {
+              key: 'Stage SDTI (Supected Deep Tissue Injury)',
               text: 'Stage SDTI (Supected Deep Tissue Injury)'
             }
           ],
@@ -3758,10 +3918,10 @@ export default function () {
           fqn: 'integumentaryAssessment.other'
         },
         {
-          elementKey: 'spacer10',
+          elementKey: 'spacer77',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'integumentaryAssessment.spacer10'
+          fqn: 'integumentaryAssessment.spacer77'
         },
         {
           elementKey: 'woundBedCalculation',
@@ -3771,6 +3931,7 @@ export default function () {
           label: '<b>Wound bed calculation</b>',
           options: [
             {
+              key: '=42+42+42+42+42+42+42+42',
               text: '=42+42+42+42+42+42+42+42'
             }
           ],
@@ -3786,16 +3947,16 @@ export default function () {
           fqn: 'integumentaryAssessment.aLabelClock'
         },
         {
-          elementKey: 'spacer11',
+          elementKey: 'spacer78',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'integumentaryAssessment.spacer11'
+          fqn: 'integumentaryAssessment.spacer78'
         },
         {
-          elementKey: 'spacer12',
+          elementKey: 'spacer79',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'integumentaryAssessment.spacer12'
+          fqn: 'integumentaryAssessment.spacer79'
         },
         {
           elementKey: 'length',
@@ -3842,39 +4003,51 @@ export default function () {
           label: 'Location',
           options: [
             {
+              key: '1',
               text: '1'
             },
             {
+              key: '2',
               text: '2'
             },
             {
+              key: '3',
               text: '3'
             },
             {
+              key: '4',
               text: '4'
             },
             {
+              key: '5',
               text: '5'
             },
             {
+              key: '6',
               text: '6'
             },
             {
+              key: '7',
               text: '7'
             },
             {
+              key: '8',
               text: '8'
             },
             {
+              key: '9',
               text: '9'
             },
             {
+              key: '10',
               text: '10'
             },
             {
+              key: '11',
               text: '11'
             },
             {
+              key: '12',
               text: '12'
             }
           ],
@@ -3885,10 +4058,10 @@ export default function () {
           helperHtml: '<p>O\'clock</p>'
         },
         {
-          elementKey: 'spacer13',
+          elementKey: 'spacer80',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'integumentaryAssessment.spacer13'
+          fqn: 'integumentaryAssessment.spacer80'
         },
         {
           elementKey: 'sinusDepth2',
@@ -3907,39 +4080,51 @@ export default function () {
           label: 'Location',
           options: [
             {
+              key: '1',
               text: '1'
             },
             {
+              key: '2',
               text: '2'
             },
             {
+              key: '3',
               text: '3'
             },
             {
+              key: '4',
               text: '4'
             },
             {
+              key: '5',
               text: '5'
             },
             {
+              key: '6',
               text: '6'
             },
             {
+              key: '7',
               text: '7'
             },
             {
+              key: '8',
               text: '8'
             },
             {
+              key: '9',
               text: '9'
             },
             {
+              key: '10',
               text: '10'
             },
             {
+              key: '11',
               text: '11'
             },
             {
+              key: '12',
               text: '12'
             }
           ],
@@ -3950,10 +4135,10 @@ export default function () {
           helperHtml: '<p>O\'clock</p>'
         },
         {
-          elementKey: 'spacer14',
+          elementKey: 'spacer81',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'integumentaryAssessment.spacer14'
+          fqn: 'integumentaryAssessment.spacer81'
         },
         {
           elementKey: 'underminingDepth1',
@@ -3972,39 +4157,51 @@ export default function () {
           label: 'Location',
           options: [
             {
+              key: '1',
               text: '1'
             },
             {
+              key: '2',
               text: '2'
             },
             {
+              key: '3',
               text: '3'
             },
             {
+              key: '4',
               text: '4'
             },
             {
+              key: '5',
               text: '5'
             },
             {
+              key: '6',
               text: '6'
             },
             {
+              key: '7',
               text: '7'
             },
             {
+              key: '8',
               text: '8'
             },
             {
+              key: '9',
               text: '9'
             },
             {
+              key: '10',
               text: '10'
             },
             {
+              key: '11',
               text: '11'
             },
             {
+              key: '12',
               text: '12'
             }
           ],
@@ -4015,10 +4212,10 @@ export default function () {
           helperHtml: '<p>O\'clock</p>'
         },
         {
-          elementKey: 'spacer15',
+          elementKey: 'spacer82',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'integumentaryAssessment.spacer15'
+          fqn: 'integumentaryAssessment.spacer82'
         },
         {
           elementKey: 'underminingDepth2',
@@ -4037,39 +4234,51 @@ export default function () {
           label: 'Location',
           options: [
             {
+              key: '1',
               text: '1'
             },
             {
+              key: '2',
               text: '2'
             },
             {
+              key: '3',
               text: '3'
             },
             {
+              key: '4',
               text: '4'
             },
             {
+              key: '5',
               text: '5'
             },
             {
+              key: '6',
               text: '6'
             },
             {
+              key: '7',
               text: '7'
             },
             {
+              key: '8',
               text: '8'
             },
             {
+              key: '9',
               text: '9'
             },
             {
+              key: '10',
               text: '10'
             },
             {
+              key: '11',
               text: '11'
             },
             {
+              key: '12',
               text: '12'
             }
           ],
@@ -4086,15 +4295,19 @@ export default function () {
           label: 'Exudate amount',
           options: [
             {
+              key: 'None',
               text: 'None'
             },
             {
+              key: 'Scant/small',
               text: 'Scant/small'
             },
             {
+              key: 'Moderate',
               text: 'Moderate'
             },
             {
+              key: 'Large/copious',
               text: 'Large/copious'
             }
           ],
@@ -4109,15 +4322,19 @@ export default function () {
           label: 'Exudate type',
           options: [
             {
+              key: 'Serous',
               text: 'Serous'
             },
             {
+              key: 'Sanguineous',
               text: 'Sanguineous'
             },
             {
+              key: 'Purulent',
               text: 'Purulent'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -4133,9 +4350,11 @@ export default function () {
           label: 'Odour present after cleansing',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -4151,15 +4370,19 @@ export default function () {
           label: 'Wound edge',
           options: [
             {
+              key: 'Attached (flush with wound bed or sloping edge)',
               text: 'Attached (flush with wound bed or sloping edge)'
             },
             {
+              key: 'Non-attached (edge appears as a cliff)',
               text: 'Non-attached (edge appears as a cliff)'
             },
             {
+              key: 'Rolled (curled under)',
               text: 'Rolled (curled under)'
             },
             {
+              key: 'Epithelialization',
               text: 'Epithelialization'
             }
           ],
@@ -4174,27 +4397,35 @@ export default function () {
           label: 'Peri-wound skin',
           options: [
             {
+              key: 'Intact',
               text: 'Intact'
             },
             {
+              key: 'Erythema (reddened) in cm',
               text: 'Erythema (reddened) in cm'
             },
             {
+              key: 'Indurated (firmness around wound) in cm',
               text: 'Indurated (firmness around wound) in cm'
             },
             {
+              key: 'Macerated (white, waterlogged)',
               text: 'Macerated (white, waterlogged)'
             },
             {
+              key: 'Excoriated/Denuded (superficial loss of tissue)',
               text: 'Excoriated/Denuded (superficial loss of tissue)'
             },
             {
+              key: 'Callused',
               text: 'Callused'
             },
             {
+              key: 'Fragile',
               text: 'Fragile'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -4240,10 +4471,10 @@ export default function () {
           helperHtml: '<p>Any depth 1cm or greater, count packing pieces</p>'
         },
         {
-          elementKey: 'spacer18',
+          elementKey: 'spacer85',
           formIndex: '1',
           inputType: 'spacer',
-          fqn: 'integumentaryAssessment.spacer18'
+          fqn: 'integumentaryAssessment.spacer85'
         },
         {
           elementKey: 'treatmentComplete',
@@ -4252,9 +4483,11 @@ export default function () {
           label: 'Treatments as per plan of care',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -4263,7 +4496,7 @@ export default function () {
           fqn: 'integumentaryAssessment.treatmentComplete'
         }
       ],
-      generated: '2019-12-27T11:25:53-08:00',
+      generated: '2020-01-02T19:02:00-08:00',
       pageElements: {
         table: {
           elementKey: 'table',
@@ -4551,7 +4784,7 @@ export default function () {
                 gChildren: [
                   'woundLabel',
                   'goalOfCare',
-                  'spacer9',
+                  'spacer76',
                   'woundLocation',
                   'woundDayOnset',
                   'woundType'
@@ -4579,7 +4812,7 @@ export default function () {
                   'underlying',
                   'notVisible',
                   'other',
-                  'spacer10',
+                  'spacer77',
                   'woundBedCalculation'
                 ]
               },
@@ -4589,20 +4822,20 @@ export default function () {
                 gIndex: '5',
                 gChildren: [
                   'aLabelClock',
-                  'spacer11',
-                  'spacer12',
+                  'spacer78',
+                  'spacer79',
                   'length',
                   'width',
                   'depth',
                   'sinusDepth1',
                   'sinusDepthLocation1',
-                  'spacer13',
+                  'spacer80',
                   'sinusDepth2',
                   'sinusDepthLocation2',
-                  'spacer14',
+                  'spacer81',
                   'underminingDepth1',
                   'underminingDepthLocation1',
-                  'spacer15',
+                  'spacer82',
                   'underminingDepth2',
                   'underminingDepthLocation2'
                 ]
@@ -4626,7 +4859,7 @@ export default function () {
                 gChildren: [
                   'packingOut',
                   'packinIn',
-                  'spacer18',
+                  'spacer85',
                   'treatmentComplete'
                 ]
               }

--- a/client/src/inside/defs-grid/external-resources.js
+++ b/client/src/inside/defs-grid/external-resources.js
@@ -155,7 +155,7 @@ export default function () {
               gChildren: [
                 {
                   label: 'Admissions',
-                  elementKey: 'subgroup116',
+                  elementKey: 'subgroup130',
                   sgChildren: [
                     'admissions1_1',
                     'admissions2_1',
@@ -164,7 +164,7 @@ export default function () {
                 },
                 {
                   label: 'Pain assessment',
-                  elementKey: 'subgroup117',
+                  elementKey: 'subgroup131',
                   sgChildren: [
                     'painAssessment1_1',
                     'painAssessment2_1'
@@ -172,7 +172,7 @@ export default function () {
                 },
                 {
                   label: 'Neurological assessment',
-                  elementKey: 'subgroup118',
+                  elementKey: 'subgroup132',
                   sgChildren: [
                     'neuroAssessment1_1',
                     'neuroAssessment2_1',
@@ -181,7 +181,7 @@ export default function () {
                 },
                 {
                   label: 'Falls risk',
-                  elementKey: 'subgroup119',
+                  elementKey: 'subgroup133',
                   sgChildren: [
                     'fallRisk1_1',
                     'fallRisk2_1'
@@ -189,14 +189,14 @@ export default function () {
                 },
                 {
                   label: 'Notes',
-                  elementKey: 'subgroup120',
+                  elementKey: 'subgroup134',
                   sgChildren: [
                     'notes1_1'
                   ]
                 },
                 {
                   label: 'Educational resources',
-                  elementKey: 'subgroup121',
+                  elementKey: 'subgroup135',
                   sgChildren: [
                     'educational1_1',
                     'educational2_1'
@@ -204,14 +204,14 @@ export default function () {
                 },
                 {
                   label: 'Wound assessment',
-                  elementKey: 'subgroup122',
+                  elementKey: 'subgroup136',
                   sgChildren: [
                     'wound1_1'
                   ]
                 },
                 {
                   label: 'Medication',
-                  elementKey: 'subgroup123',
+                  elementKey: 'subgroup137',
                   sgChildren: [
                     'medication1_1'
                   ]
@@ -345,15 +345,19 @@ export default function () {
           mandatory: 'yes',
           options: [
             {
+              key: 'M',
               text: 'M'
             },
             {
+              key: '1',
               text: '1'
             },
             {
+              key: '2',
               text: '2'
             },
             {
+              key: '3',
               text: '3'
             }
           ],

--- a/client/src/inside/defs-grid/patient-chart.js
+++ b/client/src/inside/defs-grid/patient-chart.js
@@ -194,12 +194,15 @@ export default function () {
           label: 'Status',
           options: [
             {
+              key: 'Active',
               text: 'Active'
             },
             {
+              key: 'In progress',
               text: 'In progress'
             },
             {
+              key: 'Complete',
               text: 'Complete'
             }
           ],
@@ -375,7 +378,7 @@ export default function () {
               gIndex: '1',
               gChildren: [
                 {
-                  elementKey: 'subgroup107',
+                  elementKey: 'subgroup121',
                   sgChildren: [
                     'labReport1_1',
                     'labReport2_1',

--- a/client/src/inside/defs-grid/patient-profile.js
+++ b/client/src/inside/defs-grid/patient-profile.js
@@ -83,24 +83,31 @@ export default function () {
           label: 'Gender',
           options: [
             {
+              key: 'Unknown',
               text: 'Unknown'
             },
             {
+              key: 'Female',
               text: 'Female'
             },
             {
+              key: 'Male',
               text: 'Male'
             },
             {
+              key: 'Transgender female',
               text: 'Transgender female'
             },
             {
+              key: 'Transgender male',
               text: 'Transgender male'
             },
             {
+              key: 'Undifferentiated',
               text: 'Undifferentiated'
             },
             {
+              key: 'Prefer not to say',
               text: 'Prefer not to say'
             }
           ],
@@ -115,21 +122,27 @@ export default function () {
           label: 'Martial status',
           options: [
             {
+              key: 'Married',
               text: 'Married'
             },
             {
+              key: 'Single',
               text: 'Single'
             },
             {
+              key: 'Life partner',
               text: 'Life partner'
             },
             {
+              key: 'Divorced',
               text: 'Divorced'
             },
             {
+              key: 'Separated',
               text: 'Separated'
             },
             {
+              key: 'Widowed',
               text: 'Widowed'
             }
           ],
@@ -143,18 +156,23 @@ export default function () {
           label: 'Primary language',
           options: [
             {
+              key: 'English',
               text: 'English'
             },
             {
+              key: 'French',
               text: 'French'
             },
             {
+              key: 'Spanish',
               text: 'Spanish'
             },
             {
+              key: 'German',
               text: 'German'
             },
             {
+              key: 'Chinese',
               text: 'Chinese'
             }
           ],
@@ -175,9 +193,11 @@ export default function () {
           label: 'Do you identify as an indigenous person?',
           options: [
             {
+              key: 'Yes',
               text: 'Yes'
             },
             {
+              key: 'No',
               text: 'No'
             }
           ],
@@ -290,48 +310,63 @@ export default function () {
           label: 'Next of kin relationship',
           options: [
             {
+              key: 'Wife',
               text: 'Wife'
             },
             {
+              key: 'Husband',
               text: 'Husband'
             },
             {
+              key: 'Mother',
               text: 'Mother'
             },
             {
+              key: 'Father',
               text: 'Father'
             },
             {
+              key: 'Guardian',
               text: 'Guardian'
             },
             {
+              key: 'Sister',
               text: 'Sister'
             },
             {
+              key: 'Brother',
               text: 'Brother'
             },
             {
+              key: 'Daughter',
               text: 'Daughter'
             },
             {
+              key: 'Son',
               text: 'Son'
             },
             {
+              key: 'Aunt',
               text: 'Aunt'
             },
             {
+              key: 'Uncle',
               text: 'Uncle'
             },
             {
+              key: 'Grandmother',
               text: 'Grandmother'
             },
             {
+              key: 'Grandfather',
               text: 'Grandfather'
             },
             {
+              key: 'Friend',
               text: 'Friend'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],
@@ -362,33 +397,43 @@ export default function () {
           label: 'Decision maker relationship',
           options: [
             {
+              key: 'Spouse',
               text: 'Spouse'
             },
             {
+              key: 'Child',
               text: 'Child'
             },
             {
+              key: 'Parent',
               text: 'Parent'
             },
             {
+              key: 'Sibling',
               text: 'Sibling'
             },
             {
+              key: 'Grandparent',
               text: 'Grandparent'
             },
             {
+              key: 'Grandchild',
               text: 'Grandchild'
             },
             {
+              key: 'Friend',
               text: 'Friend'
             },
             {
+              key: 'Anyone else related by partnership',
               text: 'Anyone else related by partnership'
             },
             {
+              key: 'Public guardian and trustee employee',
               text: 'Public guardian and trustee employee'
             },
             {
+              key: 'Other',
               text: 'Other'
             }
           ],

--- a/client/src/inside/defs-grid/test-page.js
+++ b/client/src/inside/defs-grid/test-page.js
@@ -68,12 +68,15 @@ export default function () {
           label: 'select',
           options: [
             {
+              key: '1=a choice 1',
               text: '1=a choice 1'
             },
             {
+              key: '2=b choice 1',
               text: '2=b choice 1'
             },
             {
+              key: '3=c choice 1',
               text: '3=c choice 1'
             }
           ],
@@ -87,12 +90,15 @@ export default function () {
           label: 'select',
           options: [
             {
+              key: '1=a choice 2',
               text: '1=a choice 2'
             },
             {
+              key: '2=b choice 2',
               text: '2=b choice 2'
             },
             {
+              key: '3=c choice 2',
               text: '3=c choice 2'
             }
           ],
@@ -116,15 +122,19 @@ export default function () {
           label: 'checkset',
           options: [
             {
+              key: 'check1=check option 1',
               text: 'check1=check option 1'
             },
             {
+              key: 'check2=check option 2',
               text: 'check2=check option 2'
             },
             {
+              key: 'other=another option',
               text: 'other=another option'
             },
             {
+              key: 'all=all options are selectable',
               text: 'all=all options are selectable'
             }
           ],
@@ -155,9 +165,11 @@ export default function () {
           label: 'select',
           options: [
             {
+              key: '1 = Yes',
               text: '1 = Yes'
             },
             {
+              key: '2 = No',
               text: '2 = No'
             }
           ],
@@ -281,11 +293,11 @@ export default function () {
           fqn: 'testPage.textDateDate'
         },
         {
-          elementKey: 'spacer128',
+          elementKey: 'spacer5',
           formIndex: '3',
           inputType: 'spacer',
           label: 'TextDate',
-          fqn: 'testPage.spacer128'
+          fqn: 'testPage.spacer5'
         },
         {
           elementKey: 'name',
@@ -302,7 +314,7 @@ export default function () {
           fqn: 'testPage.place'
         }
       ],
-      generated: '2019-10-08T07:35:50-07:00',
+      generated: '2020-01-04T08:37:17-08:00',
       pageElements: {
         form1: {
           elementKey: 'form1',
@@ -331,14 +343,14 @@ export default function () {
               gChildren: [
                 {
                   label: 'subgroup 1',
-                  elementKey: 'subgroup138',
+                  elementKey: 'subgroup20',
                   sgChildren: [
                     'pcheckset'
                   ]
                 },
                 {
                   label: 'subgroup 2',
-                  elementKey: 'subgroup139',
+                  elementKey: 'subgroup21',
                   sgChildren: [
                     'dayValue',
                     'timeValue',
@@ -348,7 +360,7 @@ export default function () {
                 },
                 {
                   label: 'subgroup 3',
-                  elementKey: 'subgroup140',
+                  elementKey: 'subgroup22',
                   sgChildren: [
                     'pcheckbox2',
                     'ptext2',
@@ -421,7 +433,7 @@ export default function () {
                 'time',
                 'textDate',
                 'textDateDate',
-                'spacer128',
+                'spacer5',
                 'name',
                 'place'
               ]
@@ -436,6 +448,7 @@ export default function () {
       pIndex: '41',
       isV2: true,
       hasGridTable: true,
+      hasGridForm: true,
       pageChildren: [
         {
           elementKey: 'e1',
@@ -506,12 +519,15 @@ export default function () {
           label: 'select',
           options: [
             {
+              key: '1=a choice 1',
               text: '1=a choice 1'
             },
             {
+              key: '2=b choice 1',
               text: '2=b choice 1'
             },
             {
+              key: '3=c choice 1',
               text: '3=c choice 1'
             }
           ],
@@ -527,12 +543,15 @@ export default function () {
           label: 'select',
           options: [
             {
+              key: '1=a choice 2',
               text: '1=a choice 2'
             },
             {
+              key: '2=b choice 2',
               text: '2=b choice 2'
             },
             {
+              key: '3=c choice 2',
               text: '3=c choice 2'
             }
           ],
@@ -558,15 +577,19 @@ export default function () {
           label: 'checkset',
           options: [
             {
+              key: 'check1=check option 1',
               text: 'check1=check option 1'
             },
             {
+              key: 'check2=check option 2',
               text: 'check2=check option 2'
             },
             {
+              key: 'other=another option',
               text: 'other=another option'
             },
             {
+              key: 'all=all options are selectable',
               text: 'all=all options are selectable'
             }
           ],
@@ -603,9 +626,11 @@ export default function () {
           label: 'select',
           options: [
             {
+              key: '1 = Yes',
               text: '1 = Yes'
             },
             {
+              key: '2 = No',
               text: '2 = No'
             }
           ],
@@ -739,13 +764,13 @@ export default function () {
           fqn: 'testTable.cd1Date'
         },
         {
-          elementKey: 'spacer134',
+          elementKey: 'spacer11',
           formIndex: '2',
           inputType: 'spacer',
           label: 'C D 1',
           tableColumn: '2',
           tableLabel: 'Chk 1',
-          fqn: 'testTable.spacer134'
+          fqn: 'testTable.spacer11'
         },
         {
           elementKey: 'cd2',
@@ -767,13 +792,13 @@ export default function () {
           fqn: 'testTable.cd2Date'
         },
         {
-          elementKey: 'spacer135',
+          elementKey: 'spacer12',
           formIndex: '2',
           inputType: 'spacer',
           label: 'C D 2',
           tableColumn: '3',
           tableLabel: 'Chk 2',
-          fqn: 'testTable.spacer135'
+          fqn: 'testTable.spacer12'
         },
         {
           elementKey: 'td1',
@@ -794,13 +819,13 @@ export default function () {
           fqn: 'testTable.td1Date'
         },
         {
-          elementKey: 'spacer136',
+          elementKey: 'spacer13',
           formIndex: '2',
           inputType: 'spacer',
           label: 'TextDate',
           tableColumn: '4',
           tableLabel: 'Txt 1',
-          fqn: 'testTable.spacer136'
+          fqn: 'testTable.spacer13'
         },
         {
           elementKey: 'referralName',
@@ -841,6 +866,7 @@ export default function () {
           inputType: 'time',
           label: 'Appointment time',
           tableColumn: '6',
+          tableLabel: 'Appointment',
           fqn: 'testTable.appointmentTime'
         },
         {
@@ -850,18 +876,146 @@ export default function () {
           label: 'Status',
           options: [
             {
+              key: 'Active',
               text: 'Active'
             },
             {
+              key: 'Discharged',
               text: 'Discharged'
             }
           ],
           tableColumn: '7',
           tableLabel: 'Status',
           fqn: 'testTable.status'
+        },
+        {
+          elementKey: 'administration',
+          formIndex: '3',
+          inputType: 'select',
+          label: 'Administration',
+          options: [
+            {
+              key: 'sched',
+              text: 'Scheduled'
+            },
+            {
+              key: 'prn',
+              text: 'PRN (as needed)'
+            },
+            {
+              key: 'once',
+              text: 'Once'
+            },
+            {
+              key: 'stat',
+              text: 'Stat'
+            }
+          ],
+          tableColumn: '7',
+          tableLabel: 'Administration',
+          fqn: 'testTable.administration'
+        },
+        {
+          elementKey: 'scheduled',
+          formIndex: '3',
+          inputType: 'select',
+          label: 'Scheduled',
+          options: [
+            {
+              key: 'BID / q12h',
+              text: 'BID / q12h'
+            },
+            {
+              key: 'TID',
+              text: 'TID'
+            },
+            {
+              key: 'q8h',
+              text: 'q8h'
+            },
+            {
+              key: 'QID',
+              text: 'QID'
+            },
+            {
+              key: 'q6h',
+              text: 'q6h'
+            },
+            {
+              key: 'q4h',
+              text: 'q4h'
+            }
+          ],
+          tableColumn: '9',
+          tableLabel: 'Scheduled',
+          fqn: 'testTable.scheduled'
+        },
+        {
+          elementKey: 'prn1',
+          formIndex: '3',
+          inputType: 'text',
+          label: 'PRN 1',
+          tableColumn: '10',
+          fqn: 'testTable.prn1'
+        },
+        {
+          elementKey: 'prn2',
+          formIndex: '3',
+          inputType: 'text',
+          label: 'PRN 2',
+          tableColumn: '11',
+          fqn: 'testTable.prn2'
+        },
+        {
+          elementKey: 'prn3',
+          formIndex: '3',
+          inputType: 'text',
+          label: 'PRN 3',
+          tableColumn: '12',
+          fqn: 'testTable.prn3'
+        },
+        {
+          elementKey: 'prn4',
+          formIndex: '3',
+          inputType: 'text',
+          label: 'PRN 4',
+          tableColumn: '13',
+          fqn: 'testTable.prn4'
+        },
+        {
+          elementKey: 'prn5',
+          formIndex: '3',
+          inputType: 'text',
+          label: 'PRN 5',
+          tableColumn: '14',
+          fqn: 'testTable.prn5'
+        },
+        {
+          elementKey: 'prn6',
+          formIndex: '3',
+          inputType: 'text',
+          label: 'PRN 6',
+          tableColumn: '15',
+          fqn: 'testTable.prn6'
+        },
+        {
+          elementKey: 'once',
+          formIndex: '3',
+          inputType: 'text',
+          label: 'Once',
+          tableColumn: '10',
+          fqn: 'testTable.once'
+        },
+        {
+          elementKey: 'stat',
+          formIndex: '3',
+          inputType: 'text',
+          label: 'Stat',
+          tableColumn: '10',
+          fqn: 'testTable.stat'
         }
       ],
-      generated: '2019-10-08T07:35:50-07:00',
+      generated: '2020-01-04T08:37:17-08:00',
       pageElements: {
         table1: {
           elementKey: 'table1',
@@ -999,14 +1153,14 @@ export default function () {
                 gChildren: [
                   {
                     label: 'subgroup 1',
-                    elementKey: 'subgroup141',
+                    elementKey: 'subgroup23',
                     sgChildren: [
                       'e10'
                     ]
                   },
                   {
                     label: 'subgroup 2',
-                    elementKey: 'subgroup142',
+                    elementKey: 'subgroup24',
                     sgChildren: [
                       'dayValue',
                       'timeValue',
@@ -1016,7 +1170,7 @@ export default function () {
                   },
                   {
                     label: 'subgroup 3',
-                    elementKey: 'subgroup143',
+                    elementKey: 'subgroup25',
                     sgChildren: [
                       'g4',
                       'g5',
@@ -1078,7 +1232,7 @@ export default function () {
               items: [
                 'cd1',
                 'cd1Date',
-                'spacer134'
+                'spacer11'
               ]
             },
             {
@@ -1087,7 +1241,7 @@ export default function () {
               items: [
                 'cd2',
                 'cd2Date',
-                'spacer135'
+                'spacer12'
               ]
             },
             {
@@ -1096,7 +1250,7 @@ export default function () {
               items: [
                 'td1',
                 'td1Date',
-                'spacer136'
+                'spacer13'
               ]
             },
             {
@@ -1144,13 +1298,13 @@ export default function () {
                 gChildren: [
                   'cd1',
                   'cd1Date',
-                  'spacer134',
+                  'spacer11',
                   'cd2',
                   'cd2Date',
-                  'spacer135',
+                  'spacer12',
                   'td1',
                   'td1Date',
-                  'spacer136'
+                  'spacer13'
                 ]
               },
               {
@@ -1183,6 +1337,49 @@ export default function () {
               status: ''
             }
           }
+        },
+        form3: {
+          elementKey: 'form3',
+          label: 'Form 3',
+          formKey: 'form3',
+          isPageForm: true,
+          ehr_groups: [
+            {
+              gIndex: '1',
+              gChildren: [
+                'administration'
+              ]
+            },
+            {
+              gIndex: '2',
+              gChildren: [
+                'scheduled'
+              ]
+            },
+            {
+              gIndex: '3',
+              gChildren: [
+                'prn1',
+                'prn2',
+                'prn3',
+                'prn4',
+                'prn5',
+                'prn6'
+              ]
+            },
+            {
+              gIndex: '4',
+              gChildren: [
+                'once'
+              ]
+            },
+            {
+              gIndex: '5',
+              gChildren: [
+                'stat'
+              ]
+            }
+          ]
         }
       }
     }

--- a/docs/developer/inside-generator/ehr-defs-input-types.md
+++ b/docs/developer/inside-generator/ehr-defs-input-types.md
@@ -60,6 +60,18 @@ may change in the future.
 Some option lists contain a set of lines of the form ```N = text```. Currently this special format is only used by the 
 calculated values (see above) yet in the future we may wish to make the left had side be the value to store in the database.
 
+> NEW key value pairs
+
+Options are now split into keys and values. By default the entire text content is the key and value.
+When the text contains ```:=``` the generator will split this into key and value. For example:
+```
+sched := Scheduled
+prn := PRN (as needed)
+once := Once
+stat := Stat
+```
+These keys can be used to control group visibility.
+
 ### formOption hideLabel
 If a select box or text box has ```hideLabel``` in its formOption then the label is not displayed
 

--- a/makeEhrV2/gen_defs/helps.js
+++ b/makeEhrV2/gen_defs/helps.js
@@ -61,10 +61,17 @@ class RawHelper {
     // 1. Split options for drop down inputs ...
     if (src.options) {
       let parts = src.options.split(nlSep)
-      let opts = parts.map(p => {
-        return { text: p }
+      dest.options = parts.map(p => {
+        let key = p
+        let text = p
+        // 2. Split on '=', if present use the sub-parts otherwise key and text are the same
+        let kv = p.split(':=')
+        if(kv.length === 2) {
+          key = kv[0].trim()
+          text= kv[1].trim()
+        }
+        return { key: key, text: text }
       })
-      dest.options = opts
     }
   }
 

--- a/makeEhrV2/hashMapFile.json
+++ b/makeEhrV2/hashMapFile.json
@@ -4,5 +4,5 @@
   "current-visit-2": "5c5196be5408c9ca071b75b0328b7063",
   "patient-chart": "e8198cad0b15784cb462a108e9e8ffd2",
   "external-resources": "d64c18e4790b2327915dd2caa6f7a05a",
-  "test-page": "9ee60bc2d35e6d62cc785de7b4049559"
+  "test-page": "9ef82e731af6247a56184809be408b36"
 }

--- a/makeEhrV2/raw_data/test-page.txt
+++ b/makeEhrV2/raw_data/test-page.txt
@@ -92,6 +92,30 @@ all=all options are selectable}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: text}	eCell	{Label: Referral profession}	{elementKey: referralProfession}	{pN: 41}	{fN: 2}	{gN: 3}	{sgN: }	eCell	eCell	eCell	{tableColumn: 5}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: spacer}	eCell	{Label: even spacers need a element key}	{elementKey: spacer1}	{pN: 41}	{fN: 2}	{gN: 3}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: date}	eCell	{Label: Appointment date}	{elementKey: appointmentDate}	{pN: 41}	{fN: 2}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Appointment}	{tableColumn: 6}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: time}	eCell	{Label: Appointment time}	{elementKey: appointmentTime}	{pN: 41}	{fN: 2}	{gN: 3}	{sgN: }	eCell	eCell	eCell	{tableColumn: 6}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: time}	eCell	{Label: Appointment time}	{elementKey: appointmentTime}	{pN: 41}	{fN: 2}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Appointment}	{tableColumn: 6}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: select}	eCell	{Label: Status}	{elementKey: status}	{pN: 41}	{fN: 2}	{gN: 3}	{sgN: }	eCell	eCell	{tableLabel: Status}	{tableColumn: 7}	eCell	eCell	eCell	eCell	"{Options: Active
 Discharged}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: page_form}	eCell	{Label: Form 3}	{elementKey: form3}	{pN: 41}	{fN: 3}	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: ehr_group}	eCell	eCell	eCell	{pN: 41}	{fN: 3}	{gN: 1}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: select}	eCell	{Label: Administration}	{elementKey: administration}	{pN: 41}	{fN: 3}	{gN: 1}	{sgN: }	eCell	eCell	{tableLabel: Administration}	{tableColumn: 7}	eCell	eCell	eCell	eCell	"{Options: sched := Scheduled
+prn := PRN (as needed)
+once := Once
+stat := Stat}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: ehr_group}	eCell	eCell	eCell	{pN: 41}	{fN: 3}	{gN: 2}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: select}	eCell	{Label: Scheduled}	{elementKey: scheduled}	{pN: 41}	{fN: 3}	{gN: 2}	{sgN: }	eCell	eCell	{tableLabel: Scheduled}	{tableColumn: 9}	eCell	eCell	eCell	eCell	"{Options: BID / q12h
+TID
+q8h
+QID
+q6h
+q4h}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: ehr_group}	eCell	eCell	eCell	{pN: 41}	{fN: 3}	{gN: 3}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: PRN 1}	{elementKey: prn1}	{pN: 41}	{fN: 3}	{gN: 3}	{sgN: }	eCell	eCell	eCell	{tableColumn: 10}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: PRN 2}	{elementKey: prn2}	{pN: 41}	{fN: 3}	{gN: 3}	{sgN: }	eCell	eCell	eCell	{tableColumn: 11}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: PRN 3}	{elementKey: prn3}	{pN: 41}	{fN: 3}	{gN: 3}	{sgN: }	eCell	eCell	eCell	{tableColumn: 12}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: PRN 4}	{elementKey: prn4}	{pN: 41}	{fN: 3}	{gN: 3}	{sgN: }	eCell	eCell	eCell	{tableColumn: 13}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: PRN 5}	{elementKey: prn5}	{pN: 41}	{fN: 3}	{gN: 3}	{sgN: }	eCell	eCell	eCell	{tableColumn: 14}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: PRN 6}	{elementKey: prn6}	{pN: 41}	{fN: 3}	{gN: 3}	{sgN: }	eCell	eCell	eCell	{tableColumn: 15}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: ehr_group}	eCell	eCell	eCell	{pN: 41}	{fN: 3}	{gN: 4}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Once}	{elementKey: once}	{pN: 41}	{fN: 3}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 10}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: ehr_group}	eCell	eCell	eCell	{pN: 41}	{fN: 3}	{gN: 5}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Stat}	{elementKey: stat}	{pN: 41}	{fN: 3}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 10}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell


### PR DESCRIPTION
Provide means to define a key for select options. Will use this to trigger medication scheduling visibility.
In the INPUTs sheet when defining the options for a select we can now provide key := value pairs (optional!) with the special characters of := as the separator.
sched := Scheduled
prn := PRN (as needed)
once := Once
stat := Stat
document the key value definition

