### PR TITLE
Outside routes

### DIFF
--- a/client/src/outsideRoutes.js
+++ b/client/src/outsideRoutes.js
@@ -9,11 +9,11 @@ export function outside () {
       meta: { layout: 'outside', label: 'Instructor', topLevel: 'undefined' }
     },
     {
-      path: '/classlist',
-      name: 'classlist',
+      path: '/classList',
+      name: 'classList',
       component: () =>
         import(/* webpackChunkName: "chunk-[request][index]" */ './outside/views/ClassList.vue'),
-      meta: { layout: 'outside', label: 'ClassList', topLevel: 'undefined' }
+      meta: { layout: 'outside', label: 'Class List', topLevel: 'undefined' }
     },
     {
       path: '/consumers',

--- a/makeEhrV2/raw_data/outsideDefs.json
+++ b/makeEhrV2/raw_data/outsideDefs.json
@@ -1,5 +1,7 @@
 [
   { "path": "", "routeName": "instructor"},
+  { "path": "", "routeName": "classList"},
+  { "path": "", "routeName": "consumers"},
   { "path": "", "routeName": "help"},
   { "path": "", "routeName": "assignments"},
   { "path": "", "routeName": "developEhrData"}


### PR DESCRIPTION
Resolve problem caused whenever we generated the definitions. Previously I added two new outside routes (pages for classlist and consumers) but I declared them explicitly in the src code. Instead they should be defined in the maker raw definitions.