### PR TITLE
Limit display of pages with seed data names

### DIFF
--- a/client/src/outside/components/EhrSeedDataList.vue
+++ b/client/src/outside/components/EhrSeedDataList.vue
@@ -21,7 +21,7 @@
               td {{sv.name}}
               td {{sv.version}}
               td {{sv.description}}
-              td {{ ehrPages(sv) }}
+              td(:title="ehrPages(sv)") {{ limitedPages(sv) }}
               td
                 div(v-for="assignment in assignmentList(sv)")
                   ui-link(:name="'assignments'", :params="{assignmentId: assignment._id}") {{ assignment.name }}
@@ -103,6 +103,16 @@ export default {
         pages = keys.join(', ')
       }
       return pages
+    },
+    limitedPages (sv) {
+      if(sv.ehrData) {
+        const keys = Object.keys(sv.ehrData)
+        if (keys.length > 1) {
+          return `${ keys.slice(0, 1).join(', ') }...`
+        } else {
+          return keys.join(', ')
+        }
+      }
     },
     uploadSeed (sv) {
       this.seedId = sv._id


### PR DESCRIPTION
This pull request addresses limiting the number of the "Pages with Seed Data" field in the EhrSeedDataList, in order for it to display only the first one of the data, concatenated with reticences (...) so that, when hovering over the word, it would display the entire list. 