### PR TITLE
Adjust size of modal so that the footer is always at the bottom

### DIFF
--- a/client/src/app/components/AppDialogShell.vue
+++ b/client/src/app/components/AppDialogShell.vue
@@ -153,7 +153,7 @@ export default {
   /*   For top and see the data properties */
   min-width: 700px;
   max-width: 1024px;
-  min-height: 40vh;
+  // min-height: 40vh;
   z-index: 999;
   background-color: $dialog-wrapper-background-color;
   border: 1px solid $grey40;


### PR DESCRIPTION
When approaching issue #499 I noticed that the modal footer was breaking, as the image shows

![image](https://user-images.githubusercontent.com/20468645/75154865-7d70be00-56ed-11ea-9692-93e65d5bc153.png)

This is probably something which didn't get merged from the previous revert of modal-fix (#535). I didn't foresee this specific use case. Please, let me know your thoughts on it