### PR TITLE
Numerous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ docs/.vuepress/dist/**
 */.env
 server/.session/
 database/data/**
+database/backup/dump/**

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -23,7 +23,7 @@ export default {
   },
   methods: {
     loadData: function () {
-      console.log('loadData triggered !!! >> ', this.$route.meta.public)
+      console.log('loadData triggered:  this.$route.meta ', this.$route.meta)
       const debugApp = false
       let params2 = getIncomingParams()
       StoreHelper.setLoading(null, true)

--- a/client/src/outside/components/AssignmentsListing.vue
+++ b/client/src/outside/components/AssignmentsListing.vue
@@ -110,7 +110,7 @@ export default {
     },
   },
   mounted: function () {
-    // TODO BG thinks this needs to be testes. Create a LMS activity with invalid external id.
+    // TODO BG thinks this needs to be tested. Create a LMS activity with invalid external id.
     // Need to give error to user. Does this do it?
     let params2 = getIncomingParams()
     this.isRespondingToError = params2['error']

--- a/client/src/store/modules/activityStore.js
+++ b/client/src/store/modules/activityStore.js
@@ -49,7 +49,7 @@ const actions = {
   },
 
   load ({dispatch, commit}, id) {
-    // at this time the switch to activity and class list component both invoke this load.
+    // at this time the switch to aactivityctivity and class list component both invoke this load.
     // commit the new id now so the class list component uses the latest as set by the switch assignment
     return dispatch('get',id)
       .then( (results) => {

--- a/client/src/store/modules/instoreHelper.js
+++ b/client/src/store/modules/instoreHelper.js
@@ -17,7 +17,7 @@ class InstoreHelperWorker {
 
   composeUrl (context, api, url) {
     let visitState = context.rootState.visit
-    let apiUrl = visitState.apiUrl
+    let apiUrl = sessionStorage.getItem('apiUrl')
     return `${apiUrl}/${api}/` + (url ? url : '')
   }
 

--- a/client/src/store/modules/instructor.js
+++ b/client/src/store/modules/instructor.js
@@ -90,7 +90,7 @@ const actions = {
     let activityId = context.rootGetters['activityStore/activityId']
     if(debug) console.log(NAME + 'load classList filtered, activityId', filtered, activityId)
     let api = 'activities'
-    let url = `class/${activityId}`
+    let url = `class-list/${activityId}`
     return InstoreHelper.getRequest(context, api, url)
       .then(response => {
         let tmpList = response.data['classList']

--- a/client/src/store/modules/visit.js
+++ b/client/src/store/modules/visit.js
@@ -23,7 +23,8 @@ const state = {
 
 const getters = {
   apiUrl: state => {
-    return state.apiUrl
+    let rval = state.apiUrl || sessionStorage.getItem(sKeys.API_URL)
+    return rval
   },
   isInstructor: state => {
     return state.sVisitData.isInstructor

--- a/deployment/database/backup.sh
+++ b/deployment/database/backup.sh
@@ -1,1 +1,1 @@
-mongodump --db edehr-prod
+mongodump --db edehr-prod --authenticationDatabase admin -u root

--- a/deployment/database/restore.sh
+++ b/deployment/database/restore.sh
@@ -1,1 +1,5 @@
-mongorestore --db edehr-prod ./dump/edehr-prod/
+mongorestore --authenticationDatabase admin -u root --db edehr-prod ./dump/edehr-prod/
+
+# mongorestore --authenticationDatabase admin -u root --db edehr-dev ./dump/edehr-dev/
+
+# mongorestore --db edehr-dev edehr-dev/

--- a/server/src/mcr/activity-data/activity-data-controller.js
+++ b/server/src/mcr/activity-data/activity-data-controller.js
@@ -20,8 +20,8 @@ export default class ActivityDataController extends BaseController {
    * @return {*}
    */
   updateAssignmentData (id, data) {
-    var propertyName = data.propertyName
-    var value = data.value
+    const propertyName = data.propertyName
+    const value = data.value
     value.lastUpdate = moment().format()
     // debug(`ActivityData update ${id} assignmentData[${data.propertyName}] with data:`)
     // debug(JSON.stringify(value))
@@ -46,7 +46,7 @@ export default class ActivityDataController extends BaseController {
    */
   updateScratchData (id, data) {
     debug(`ActivityData update ${id} scratch data [${JSON.stringify(data)}]`)
-    var value = data.value
+    const value = data.value
     return this.baseFindOneQuery(id).then(activityData => {
       if (activityData) {
         activityData.lastDate = Date.now()
@@ -77,10 +77,12 @@ export default class ActivityDataController extends BaseController {
     })
   }
 
-  helperBoolVal (id, property, value) {
+  helperBoolVal (id, property, value, isStudentAction) {
     return this.baseFindOneQuery(id).then(activityData => {
       if (activityData) {
-        activityData.lastDate = Date.now()
+        if (isStudentAction) {
+          activityData.lastDate = Date.now()
+        }
         activityData[property] = value
         return activityData.save()
       }
@@ -89,12 +91,12 @@ export default class ActivityDataController extends BaseController {
 
   assignmentSubmitted (id, data) {
     let value = data.value === true
-    return this.helperBoolVal(id, 'submitted', value)
+    return this.helperBoolVal(id, 'submitted', value, true)
   }
 
   assignmentEvaluated (id, data) {
     let value = data.value === true
-    return this.helperBoolVal(id, 'evaluated', value)
+    return this.helperBoolVal(id, 'evaluated', value, false)
   }
 
   route () {

--- a/server/src/mcr/activity/activity-controller.js
+++ b/server/src/mcr/activity/activity-controller.js
@@ -13,20 +13,38 @@ export default class ActivityController extends BaseController {
     super(Activity, '_id')
   }
 
+  closeActivity (id, direction) {
+    return this.baseFindOneQuery(id).then(activity => {
+      if (activity) {
+        activity.closedDate = Date.now()
+        activity.open = direction
+        return activity.save()
+      }
+    })
+  }
+
+  /**
+   * Called by the LTI controller when a user comes to this system.
+   *
+   * @param ltiData
+   * @param toolConsumerId
+   * @param assignment
+   * @return {Promise<any>}
+   */
   updateCreateActivity (ltiData, toolConsumerId, assignment) {
     const _this = this
     debug('updateCreateActivity search for existing activity ' + ltiData.resource_link_id)
     return new Promise(function (resolve, reject) {
-      var data = _this._extractLtiData(ltiData)
+      const data = _this._extractLtiData(ltiData)
       _this.findOne({$and: [{resource_link_id: ltiData.resource_link_id}, {toolConsumer: toolConsumerId}]})
         .then((activity) => {
           if (activity) {
+            activity.lastDate = Date.now()
             if (!activity.assignment.equals(assignment._id)) {
             // console.log('was ', activity.assignment, 'seeking', assignment._id)
-              var msg = 'Changing assignment for this activity.'
+              const msg = 'Changing assignment for this activity.'
               debug('updateCreateActivity ' + msg)
               activity.assignment = assignment._id
-            // console.log('adasd',activity)
             }
             debug('updateCreateActivity update activity ' + activity._id)
             return _this._updateHelper(activity, data)
@@ -44,12 +62,6 @@ export default class ActivityController extends BaseController {
   }
 
   listClassList (_id) {
-    // TODO elide the student's scratch pad
-    /*
-      .findOne({personcode: code})
-      .select('-_id -__v')
-      .populate('bookids', '-_id -__v')
-     */
     return Visit.find({ $and: [ {isStudent: true }, {activity: _id} ] })
       .populate('activityData', 'submitted evaluated assignmentData evaluationData')
       .populate('assignment', 'externalId name description seedDataId ehrRoutePath')
@@ -66,10 +78,10 @@ export default class ActivityController extends BaseController {
   }
 
   _createHelper (activity, data) {
-    debug('updateCreateActivity create new activity record ' + JSON.stringify((data)))
+    debug('createHelper create new activity record ' + JSON.stringify((data)))
     return this.create(data)
       .then((newActivity) => {
-        debug('updateCreateActivity new activity ' + newActivity._id)
+        debug('createHelper new activity ' + newActivity._id)
         return newActivity
       })
   }
@@ -78,10 +90,10 @@ export default class ActivityController extends BaseController {
     Object.assign(activity, data)
     let updated = JSON.stringify(activity)
     if (current !== updated) {
-      debug('updateCreateActivity there is something different in the activity. Saving new activity data ' + updated)
+      debug('updateHelper there is something different in the activity. Saving new activity data ' + updated)
       return activity.save()
     } else {
-      debug('updateCreateActivity  no change in activity')
+      debug('updateHelper  no change in activity')
       return activity
     }
   }
@@ -102,7 +114,7 @@ export default class ActivityController extends BaseController {
   route () {
     const router = super.route()
 
-    router.get('/class/:key', (req, res) => {
+    router.get('/class-list/:key', (req, res) => {
       this
         .listClassList(req.params.key)
         .then(ok(res))
@@ -114,6 +126,22 @@ export default class ActivityController extends BaseController {
         .then(ok(res))
         .then(null, fail(res))
     })
+
+    // PUT
+    router.put('/close-activity/:key', (req, res) => {
+      this
+        .closeActivity(req.params.key, true)
+        .then(ok(res))
+        .then(null, fail(res))
+    })
+
+    router.put('/open-activity/:key', (req, res) => {
+      this
+      .closeActivity(req.params.key, false)
+      .then(ok(res))
+      .then(null, fail(res))
+    })
+
     return router
   }
 }

--- a/server/src/mcr/activity/activity.js
+++ b/server/src/mcr/activity/activity.js
@@ -4,9 +4,10 @@ const ObjectId = mongoose.Schema.Types.ObjectId
 /*
 An Activity is a tool consumer assignment.
 Within any Consumer the resource_link_id is an unique id referencing the link, or "placement", of the app in the consumer.
-If an app was added twice to the same class, each placement would send a different id, and should be considered a unique "launch".
+If an app was added twice to the same class, each placement would send a different id, and
+should be considered a unique "launch".
 
- The context_id is the course id in the LMS.
+The context_id is the course id in the LMS.
 The resource_link_id is the assignment id in the LMS.
 
 The custom_assignment value is the link to the EdEHR seed data.
@@ -23,9 +24,11 @@ const Schema = new mongoose.Schema({
   context_type: {type: String}, // ltiData.context_type,
   resource_link_title: {type: String}, // ltiData.resource_link_title,
   resource_link_description: {type: String}, // ltiData.resource_link_description,
-  // TODO consider just storing the external id/ custom_assignment and use it as lookup key
   assignment: {type: ObjectId, ref: 'Assignment'}, // ltiData.custom_assignment,
-  createDate: {type: Date, default: Date.now}
+  open: {type: Boolean, default: true},
+  createDate: {type: Date, default: Date.now},
+  closedDate: {type: Date},
+  lastDate: {type: Date, default: Date.now}
 })
 
 const Activity = mongoose.model('Activity', Schema)

--- a/server/src/mcr/common/base.js
+++ b/server/src/mcr/common/base.js
@@ -4,7 +4,7 @@ import pluralize from 'pluralize'
 import {ok, fail} from './utils'
 import {SystemError} from './errors'
 
-const MAX_RESULTS = 100
+const MAX_RESULTS = 1000
 // var emptyPromise = function (t) {return new Promise (function (r, e) { r (t); }); };
 
 /**


### PR DESCRIPTION
Update backup scripts with command that works on prod.
Change api limit on lists. from 100 to 1000.
Activity db object add: CreatedDate, LastUpdateDate, ClosedDate and a flag to say if the activity is still open for students.
Activity controller add two PUT endpoints: close-activity and open-activity.
ActivityDataController now only updates LastUpdate if the student makes the change.
If the vuex store does not have the API URL then use session storage (begs the question why not us ss all the time?).
Change url for class list API end point from /class to /class-list.
Numerous comments updated.



