### PR TITLE
Activity can be closed

### DIFF
--- a/client/src/helpers/eval-helper.js
+++ b/client/src/helpers/eval-helper.js
@@ -106,6 +106,21 @@ class EvalHelperWorker {
       })
   }
 
+  closeActivity (activityId) {
+    return StoreHelper.closeActivity(activityId)
+      .then(() => {
+        return StoreHelper.loadAsCurrentActivity(activityId)
+      })
+  }
+
+  openActivity (activityId) {
+    return StoreHelper.openActivity(activityId)
+      .then(() => {
+        return StoreHelper.loadAsCurrentActivity(activityId)
+      })
+  }
+
+
   goToEhr (studentVisit) {
     // Assumes the activity and assignment and seed are all in place.
     // switch to the EHR with the current student's information loaded

--- a/client/src/helpers/store-helper.js
+++ b/client/src/helpers/store-helper.js
@@ -103,6 +103,14 @@ class StoreHelperWorker {
 
   getActivityDescription () { return this._getActivityProperty('activityDescription') }
 
+  getActivityIsClosed () {
+    return this._getActivityProperty('closed')
+  }
+
+  getActivityClosedDate () {
+    return this._getActivityProperty('closedDate')
+  }
+
   activitiesUsingAssignmentCount (assignmentId) {
     let cnt = 0
     let courses = this.getCourseList()
@@ -125,6 +133,20 @@ class StoreHelperWorker {
    * @return {*}
    */
   loadAsCurrentActivity (activityId) { return this._dispatchActivity('load', activityId) }
+
+  /**
+   * Make API call to close activity
+   * @param activityId
+   * @return {*}
+   */
+  closeActivity (activityId) { return this._dispatchActivity('close', activityId) }
+
+  /**
+   * Make API call to open activity
+   * @param activityId
+   * @return {*}
+   */
+  openActivity (activityId) { return this._dispatchActivity('open', activityId) }
 
   currentStudentId () { return this._getInstructorProperty('currentStudentId') }
 
@@ -229,6 +251,8 @@ class StoreHelperWorker {
       courseTitle: this.getCourseTitle(),
       activityTitle: this.getActivityTitle(),
       activityDescription: this.getActivityDescription(),
+      closed: this.getActivityIsClosed(),
+      closedDate: this.getActivityClosedDate(),
       assignmentName: assignment.name,
       assignmentDescription: assignment.description,
       submitted: this.isSubmitted(),

--- a/client/src/inside/components/EhrContextInstructor.vue
+++ b/client/src/inside/components/EhrContextInstructor.vue
@@ -10,6 +10,7 @@
       div(class="is-4 column")
         div(class="textField") Student: {{ panelInfo.studentName }}
         div(class="textField") Student's last visit: {{ formatTime(panelInfo.lastVisitDate) }}
+        div Activity is {{ panelInfo.closed ? "CLOSED " : "OPEN "}} to students
         div(class="textField") Return to  &nbsp;
           ui-link(:name="'classList'") classlist
       div(class="is-4 column")
@@ -54,13 +55,13 @@ export default {
       return StoreHelper.getPanelData()
     },
     classList () {
-      /*
-      Filter the class list to only show records for students who have submitted their work
-       */
       let list = StoreHelper.getClassList()
-      list = list.filter( sv => {
-        return sv.activityData.submitted
-      })
+      if(!this.panelInfo.closed) {
+        // Filter the class list to only show records for students who have submitted their work
+        list = list.filter(sv => {
+          return sv.activityData.submitted
+        })
+      }
       return list
     },
     currentStudentId () {

--- a/client/src/inside/components/EhrContextStudent.vue
+++ b/client/src/inside/components/EhrContextStudent.vue
@@ -1,10 +1,11 @@
 <template lang="pug">
   div(class="contextStudent")
-    div(v-if="isEvaluated", class="EhrContextBanner")
+    div(v-if="showContext", class="EhrContextBanner")
       div(class="EhrPanelContent")
         h3 {{ panelInfo.courseTitle}} - {{ panelInfo.assignmentName}}
-        p Student: {{ userName }}
-        p Evaluation: {{ evaluationNotes }}
+        div(v-if="isClosed") Activity closed as of {{ closedDate | formatDateTime }}
+        div Student: {{ userName }}
+        div Evaluation: {{ evaluationNotes }}
 </template>
 
 <script>
@@ -17,9 +18,12 @@ export default {
     userName ()         { return this.panelInfo.userName },
     scratchData ()      { return this.panelInfo.scratchData },
     submitted ()        { return this.panelInfo.submitted },
+    isClosed ()         { return this.panelInfo.closed },
+    closedDate ()       { return this.panelInfo.closedDate },
     isEvaluated ()      { return this.panelInfo.evaluated },
     evaluationNotes ()  { return this.panelInfo.evaluationData },
-    panelInfo ()        { return StoreHelper.getPanelData(this) }
+    panelInfo ()        { return StoreHelper.getPanelData(this) },
+    showContext ()      { return this.isEvaluated || this.isClosed }
   },
   methods: {}
 }

--- a/client/src/inside/components/EhrNavPanelAction.vue
+++ b/client/src/inside/components/EhrNavPanelAction.vue
@@ -27,6 +27,7 @@ import UiAgree from '../../app/ui/UiAgree.vue'
 import EhrActions from '../../helpers/ehr-actions'
 import { postFeedback } from '../../helpers/feedback'
 import AppDialog from '../../app/components/AppDialogShell.vue'
+import StoreHelper from '../../helpers/store-helper'
 
 const FEEDBACK_TITLE = 'Optional Feedback Form'
 const FEEDBACK_BODY = 'Your assignment has been submitted successfully.  Before you leave, '+
@@ -63,7 +64,7 @@ export default {
       return require('../../menuList.json')
     },
     showNavAction () {
-      return this.$store.getters['visit/isStudent']
+      return !StoreHelper.getActivityIsClosed() && this.$store.getters['visit/isStudent']
     },
     disableNavAction () {
       return this.$store.state.system.isEditing

--- a/client/src/inside/components/page/EhrPageForm.vue
+++ b/client/src/inside/components/page/EhrPageForm.vue
@@ -9,7 +9,7 @@
         ul
           li(v-for="error in errors") {{ error }}
       ehr-group(v-for="group in groups", :key="group.gIndex", :group="group", :ehrHelp="ehrHelp")
-      div(class="resetFormButton")
+      div(v-if="canEdit", class="resetFormButton")
         ui-button(
           v-on:buttonClicked="promptConfirmDialog", 
           v-bind:secondary="true",
@@ -56,6 +56,9 @@ export default {
     ehrHelp: { type: Object }
   },
   computed: {
+    canEdit () {
+      return this.ehrHelp._canEdit()
+    },
     formKey () {
       return this.form.elementKey
     },

--- a/client/src/inside/components/page/ehr-helper.js
+++ b/client/src/inside/components/page/ehr-helper.js
@@ -110,6 +110,10 @@ export default class EhrHelpV2 {
     return StoreHelper.isSubmitted()
   }
 
+  _isActivityOpen () {
+    return !StoreHelper.getActivityIsClosed()
+  }
+
   /**
    * Show or don't show page edit controls or table open dialog buttons.
    * Currently the rule is simply "is the user a student" but this will need to
@@ -122,7 +126,7 @@ export default class EhrHelpV2 {
   }
 
   _canEdit () {
-    let studentCanEdit = this._isStudent() && !this._isSubmitted()
+    let studentCanEdit = this._isActivityOpen() && this._isStudent() && !this._isSubmitted()
     return studentCanEdit || this._isDevelopingContent()
   }
 

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import App from './App.vue'
+import moment from 'moment'
 import router from './router'
 import store from './store'
 import outsideLayout from './outside/layout/LayoutOutside.vue'
@@ -30,6 +31,8 @@ import {
   faClock,
   faCircle,
   faInfoCircle,
+  faHourglassEnd,
+  faHourglassStart,
   faArrowRight,
   faArrowLeft,
   faNotesMedical,
@@ -43,6 +46,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 library.add(faCheckCircle, faCircle, faTimesCircle, faTimes, faPlus, faMinus, faAngleRight, faAngleLeft)
 library.add(faClock, faInfoCircle, faArrowRight, faArrowLeft, faNotesMedical)
 library.add(faEdit, faDownload, faUpload, faFilePdf, faStickyNote)
+library.add(faHourglassEnd, faHourglassStart)
 // IN CODE sample usage is:
 // fas-icon(icon="download")
 Vue.component('fas-icon', FontAwesomeIcon)
@@ -59,6 +63,17 @@ Vue.directive('dragged', dragDirective)
 Vue.directive('resized', resizeDirective)
 Vue.directive('textToHtml', textToHtml) // used as text-to-html attribute
 Vue.directive('validate', validate)
+
+Vue.filter('formatDateDMY', function (value) {
+  return moment(value).format('DD MMM YYYY')
+})
+Vue.filter('formatDateYMD', function (value) {
+  return moment(value).format('YYYY-MM-DD')
+})
+Vue.filter('formatDateTime', function (value) {
+  return moment(value).format('YYYY-MM-DD h:mm a')
+})
+
 
 /*
 Create the root Vue component.

--- a/client/src/outside/components/Activity.vue
+++ b/client/src/outside/components/Activity.vue
@@ -2,7 +2,7 @@
   div(:id="activityId")
     div(class="activity-list-header columns", v-on:click="toggleShow")
       div(class="header-column is-10 column")
-        h3(:title="activityId") {{ activityName }}
+        h3(:title="activityId") {{ activityName }}  IS THIS COMPONENT USED ANYMORE?
         accordion-element(theme="grayTheme", :show="show")
           table
             tr

--- a/client/src/store/modules/activityStore.js
+++ b/client/src/store/modules/activityStore.js
@@ -36,6 +36,11 @@ const getters = {
     if(debug) console.log(NAME + ' get activityDescription', prop)
     return prop
   },
+  closed: state => {
+    let prop =  state.dataStore.closed
+    if(debug) console.log(NAME + ' get dataStore.closed', prop)
+    return prop
+  }
 }
 
 const actions = {
@@ -46,6 +51,27 @@ const actions = {
       return dispatch('load', actId)
     }
     return Promise.resolve()
+  },
+
+  close ({dispatch, commit}, id) {
+    let url = 'close-activity/' + id
+    let payload = { url:url, data: { }}
+    return dispatch('put', payload)
+      .then( (results) => {
+        if(debug) console.log(NAME + ' loaded ', results)
+        commit('set', results)
+        return results
+      })
+  },
+  open ({dispatch, commit}, id) {
+    let url = 'open-activity/' + id
+    let payload = { url:url, data: { }}
+    return dispatch('put', payload)
+      .then( (results) => {
+        if(debug) console.log(NAME + ' loaded ', results)
+        commit('set', results)
+        return results
+      })
   },
 
   load ({dispatch, commit}, id) {

--- a/client/src/store/modules/instoreHelper.js
+++ b/client/src/store/modules/instoreHelper.js
@@ -16,7 +16,6 @@ const debug = false
 class InstoreHelperWorker {
 
   composeUrl (context, api, url) {
-    let visitState = context.rootState.visit
     let apiUrl = sessionStorage.getItem('apiUrl')
     return `${apiUrl}/${api}/` + (url ? url : '')
   }

--- a/client/src/store/modules/instructor.js
+++ b/client/src/store/modules/instructor.js
@@ -87,22 +87,20 @@ const actions = {
   },
 
   loadClassList (context, filtered) {
+    console.debug('Instructor store no longer filters list. TODO clean up.')
     let activityId = context.rootGetters['activityStore/activityId']
     if(debug) console.log(NAME + 'load classList filtered, activityId', filtered, activityId)
     let api = 'activities'
     let url = `class-list/${activityId}`
     return InstoreHelper.getRequest(context, api, url)
       .then(response => {
-        let tmpList = response.data['classList']
-        let classList = filtered ? tmpList.filter( elem => elem.activityData.submitted ) : tmpList
+        let classList = response.data['classList']
         let len = classList.length
         classList.forEach (( elem, index )  => {
           elem.index = index
           elem.listLength = len
         })
         if(debug) {
-          console.log(NAME + 'cl filtered', filtered)
-          console.log(NAME + 'cl tmpList', tmpList)
           console.log(NAME + 'cl classList', classList)
         }
         context.commit('setClassList', classList)

--- a/server/src/mcr/activity/activity-controller.js
+++ b/server/src/mcr/activity/activity-controller.js
@@ -17,7 +17,7 @@ export default class ActivityController extends BaseController {
     return this.baseFindOneQuery(id).then(activity => {
       if (activity) {
         activity.closedDate = Date.now()
-        activity.open = direction
+        activity.closed = direction === 'close'
         return activity.save()
       }
     })
@@ -130,16 +130,16 @@ export default class ActivityController extends BaseController {
     // PUT
     router.put('/close-activity/:key', (req, res) => {
       this
-        .closeActivity(req.params.key, true)
+        .closeActivity(req.params.key, 'close')
         .then(ok(res))
         .then(null, fail(res))
     })
 
     router.put('/open-activity/:key', (req, res) => {
       this
-      .closeActivity(req.params.key, false)
-      .then(ok(res))
-      .then(null, fail(res))
+        .closeActivity(req.params.key, 'open')
+        .then(ok(res))
+        .then(null, fail(res))
     })
 
     return router

--- a/server/src/mcr/activity/activity.js
+++ b/server/src/mcr/activity/activity.js
@@ -25,7 +25,7 @@ const Schema = new mongoose.Schema({
   resource_link_title: {type: String}, // ltiData.resource_link_title,
   resource_link_description: {type: String}, // ltiData.resource_link_description,
   assignment: {type: ObjectId, ref: 'Assignment'}, // ltiData.custom_assignment,
-  open: {type: Boolean, default: true},
+  closed: {type: Boolean, default: false},
   createDate: {type: Date, default: Date.now},
   closedDate: {type: Date},
   lastDate: {type: Date, default: Date.now}


### PR DESCRIPTION
The instructor can now press a button on the class list page and close (or reopen) an activity for students. When the activity is closed the instructor can now evaluate all the student's work and not just the students who submitted.
The Class list page has also been reworked to show the instructor more information about the current state of the activity.
API change, adding in the closed property to the activity record.
Adding some data and time formatting directives into the system. These are used on the class list page.
A couple of TODO are added into the code.  
1. clean up the load class list methods to not use the filter property. 
2. See if the Activity component is still in use.  
3. See if we can remove the watch() in ClassList.vue
Student experience when activity is closed
- Disable edit.
- Don't show nav panel actions
- Show student evaluation panel with date closed


