### PR TITLE
Remove faulty sys message for instructors

### DIFF
--- a/client/src/app/components/SystemMessage.vue
+++ b/client/src/app/components/SystemMessage.vue
@@ -41,12 +41,6 @@ export default {
       if (StoreHelper.isStudent(this)) {
         if (StoreHelper.isSubmitted(this)) {
           msg = Text.STUDENT_HAS_SUBMITTED
-        } else {
-          msg = Text.STUDENT_INTRO
-        }
-      } else if (StoreHelper.isInstructor(this)){
-        if (StoreHelper.isEvaluated(this)) {
-          msg = Text.ASSIGNMENT_HAS_BEEN_EVALUATED
         }
       }
       // uncomment to set a test message


### PR DESCRIPTION
The sys message was telling the instructor that a whole class list was sent to the student if one student's work was sent.  This message is not correct and best handled, if needed, in the evaluation panel while an instructor is evaluating the student.