### PR TITLE
Storage initialization cleanup

### DIFF
--- a/client/src/helpers/auth-helper.js
+++ b/client/src/helpers/auth-helper.js
@@ -5,23 +5,17 @@ import { Text } from './ehr-text'
 const debugA = false
 
 class AuthHelper {
-  _getApiUrl () {
-    const url = StoreHelper.apiUrlGet()
-    if (debugA) console.log('AuthHelper api url is ', url)
-    return url
-  }
-
   // Overall auth logic
   getToken (refreshToken) {
     if (debugA) console.log('AuthHelper getToken ')
-    const apiUrl = this._getApiUrl()
+    const apiUrl = StoreHelper.apiUrlGet()
     const url = `${apiUrl}/auth/refresh`
     return axios.post(url, {refreshToken})
   }
 
   getData () {
     if (debugA) console.log('AuthHelper getData ')
-    const apiUrl = this._getApiUrl()
+    const apiUrl = StoreHelper.apiUrlGet()
     const url = `${apiUrl}/auth/`
     return axios.post(url, null)
       .catch(err => {
@@ -33,7 +27,7 @@ class AuthHelper {
   // Admin requests
   adminLogin (adminPass) {
     if (debugA) console.log('AuthHelper adminLogin ')
-    const apiUrl = this._getApiUrl()
+    const apiUrl = StoreHelper.apiUrlGet()
     const url = `${apiUrl}/admin`
     return axios.post(url, {adminPass})
   }

--- a/client/src/helpers/demo-helper.js
+++ b/client/src/helpers/demo-helper.js
@@ -7,20 +7,16 @@ const debugDH = false
 
 class DemoHelper {
 
-  _getApiUrl () {
-    return StoreHelper.apiUrlGet()
-  }
-
   createToolConsumer () {
     const id = uuid()
-    const apiUrl = this._getApiUrl()
+    const apiUrl = StoreHelper.apiUrlGet()
     if(debugDH) console.log('DH create consumer for user id ', id, apiUrl)
     const url = `${apiUrl}/demo/`
     return axios.post(url, { id })
   }
 
   demoLogout (token) {
-    const apiUrl = this._getApiUrl()
+    const apiUrl = StoreHelper.apiUrlGet()
     const url = `${apiUrl}/demo/logout`
     if(debugDH) console.log('DH logout',apiUrl)
     setAuthHeader(token)
@@ -31,7 +27,7 @@ class DemoHelper {
   }
 
   dhLoadDemoData (token) {
-    const apiUrl = this._getApiUrl()
+    const apiUrl = StoreHelper.apiUrlGet()
     const url = `${apiUrl}/demo/fetch`
     if(debugDH) console.log('DH fetch', apiUrl)
     setAuthHeader(token)
@@ -39,7 +35,7 @@ class DemoHelper {
   }
 
   submitPersona (token, submitData) {
-    const apiUrl = this._getApiUrl()
+    const apiUrl = StoreHelper.apiUrlGet()
     const url = `${apiUrl}/demo/set`
     const {assignmentName, externalId, personaName, personaEmail, personaRole, returnUrl, toolKey} = submitData
     const [ given, family ] = personaName.split(' ')

--- a/client/src/helpers/eval-helper.js
+++ b/client/src/helpers/eval-helper.js
@@ -1,10 +1,6 @@
 import router from '../router'
 import StoreHelper from './store-helper'
 
-// import { downArrayToCsvFile } from './ehr-utils'
-
-// const debug = false
-
 /**
  * Helper class with methods that assist instructors during evaluation of student's work.
  * Includes actions
@@ -17,59 +13,6 @@ import StoreHelper from './store-helper'
  *
  */
 class EvalHelperWorker {
-
-  /*
-  atStart () {
-    let index = this.findCurrentIndex()
-    return index === 0
-  }
-  atEnd () {
-    let index = this.findCurrentIndex()
-    return index + 1 < list.length
-  }
-  findCurrentIndex () {
-    let id = this.currentStudentId()
-    let classList = this.getClassList()
-    let index = classList.findIndex(function (elem) {
-      return elem._id === id
-    })
-    console.log('findCurrentIndex', id, ' index:', index, this.classList)
-    return { list, index }
-  }
-  gotoPrevious () {
-    let sv
-    let classList = this.getClassList()
-    let index = this.findCurrentIndex()
-    index--
-    if (index >= 0) {
-      let sv = classList[index]
-      this.changeStudent(sv)
-    }
-    return sv
-  }
-  gotoNext () {
-    let sv
-    let classList = this.getClassList()
-    let index = this.findCurrentIndex()
-    index++
-    if (index < classList.length) {
-      let sv = classList[index]
-      this.changeStudent(sv)
-    }
-    return sv
-  }
-  */
-  /*
-
-  proceed (filename) {
-    let data = []
-    data.push(['email','feedback: ' + this.activityName])
-    this.classList.forEach ( sv => {
-      data.push([sv.user.emailPrimary,sv.activityData.evaluationData])
-    })
-    downArrayToCsvFile(filename, data)
-  }
-  */
 
   forceSubmit (studentVisit) {
     console.log('EvalHelper forceSubmit sv', studentVisit)

--- a/client/src/helpers/session-keys.js
+++ b/client/src/helpers/session-keys.js
@@ -3,8 +3,6 @@ const sKeys = {
   API_URL: 'apiUrl',
   SEED_ID: 'seedId',
   USER_TOKEN: 'token',
-  C_STUDENT: 'sCurrentEvaluationStudentId',
-  C_ACTIVITY: 'currentActivityId',
   IS_DEVING: 'isSeedEditing',
   AUTH_TOKEN: 'authToken',
   IS_READONLY_INSTRUCTOR: 'isReadOnlyInstructor',

--- a/client/src/helpers/store-helper.js
+++ b/client/src/helpers/store-helper.js
@@ -106,7 +106,7 @@ class StoreHelperWorker {
 
   dispatchLoadClassList ( filtered ) { return this._dispatchInstructor('loadClassList', filtered)  }
 
-  getCurrentEvaluationStudentId () { return this._getInstructorProperty('currentStudentId') }
+  getCurrentEvaluationStudentId () { return this._getInstructorProperty('currentEvaluationStudentId') }
 
   getCurrentEvaluationStudentVisit () { return this._getInstructorProperty('currentEvaluationStudent') }
 
@@ -177,8 +177,6 @@ class StoreHelperWorker {
    * @return {*}
    */
   openActivity (activityId) { return this._dispatchActivity('open', activityId) }
-
-  currentStudentId () { return this._getInstructorProperty('currentStudentId') }
 
   getCourseList () { return store.state.instructor.sCourses || [] }
 
@@ -329,24 +327,7 @@ class StoreHelperWorker {
     }
   }
 
-  restoreSession () {
-    let visitId = sessionStorage.getItem(sKeys.USER_TOKEN)
-    if (debugSH) console.log('SH No visit id in url query. Is it in session storage? visitId', visitId)
-    if (visitId) {
-      return this._dispatchActivity('sessionRestore')
-        .then ( () => {
-          return this._dispatchInstructor('sessionRestore')
-        })
-        .then( () => {
-          return visitId
-        })
-    }
-    return visitId
-  }
-
   clearSession () {
-    sessionStorage.removeItem(sKeys.C_ACTIVITY)
-    sessionStorage.removeItem(sKeys.C_STUDENT)
     sessionStorage.removeItem(sKeys.SEED_ID)
     sessionStorage.removeItem(sKeys.IS_READONLY_INSTRUCTOR)
     return Promise.resolve()

--- a/client/src/helpers/test/auth-helper.spec.js
+++ b/client/src/helpers/test/auth-helper.spec.js
@@ -1,9 +1,6 @@
 const should = require('should')
 import authHelper from '../auth-helper'
 import { prepareAxiosResponse } from './axios-mock-helper'
-import StoreHelper from '../store-helper'
-import { setAPIUrl } from './testHelper'
-
 jest.mock('axios')
 
 const refreshToken = 'testRefreshToken'

--- a/client/src/helpers/test/auth-helper.spec.js
+++ b/client/src/helpers/test/auth-helper.spec.js
@@ -40,11 +40,4 @@ describe('auth-helper tests', () => {
     })
   })
 
-  it('_getApiUrl', done => {
-    setAPIUrl()
-    const storeUrl = StoreHelper.apiUrlGet()
-    const _apiUrl = authHelper._getApiUrl()
-    _apiUrl.should.equal(storeUrl)
-    done()
-  })
 })

--- a/client/src/helpers/test/demo-helper.spec.js
+++ b/client/src/helpers/test/demo-helper.spec.js
@@ -1,8 +1,6 @@
 import should from 'should'
 import demoHelper from '../demo-helper'
-import { setAPIUrl } from './testHelper'
 import { prepareAxiosResponse } from './axios-mock-helper'
-import StoreHelper from '../store-helper'
 import mockData from './mockData.json'
 
 jest.mock('axios')

--- a/client/src/helpers/test/demo-helper.spec.js
+++ b/client/src/helpers/test/demo-helper.spec.js
@@ -10,13 +10,6 @@ jest.mock('axios')
 const token = 'demoToken'
 
 describe('demoHelper tests', () => {
-  it('_getApiUrl', done => {
-    setAPIUrl()
-    const storeUrl = StoreHelper.apiUrlGet()
-    const url = demoHelper._getApiUrl()
-    url.should.equal(storeUrl)
-    done()
-  })
 
   it('createToolConsumer', async done => {
     const payload = { token }

--- a/client/src/helpers/test/ehr-utils.spec.js
+++ b/client/src/helpers/test/ehr-utils.spec.js
@@ -258,15 +258,15 @@ describe('Test validators and formatters ', () => {
   })
 
   it('formatDateStr', done => {
-    ehrUtils.formatDateStr('10/11/2011').should.equal('11 Oct 2011')
-    ehrUtils.formatDateStr('04/01/2012').should.equal('01 Apr 2012')  
+    ehrUtils.formatDateStr('2011-10-11').should.equal('11 Oct 2011')
+    ehrUtils.formatDateStr('2012-04-01').should.equal('01 Apr 2012')
     done()
   })
 
   it('formatTimeStr', done => {
-    ehrUtils.formatTimeStr('10/11/2011 12:00').should.equal('2011-10-11 12:00 pm')
-    ehrUtils.formatTimeStr('10/11/2011 15:00').should.equal('2011-10-11 3:00 pm')
-    ehrUtils.formatTimeStr('10/11/2011 00:00').should.equal('2011-10-11 12:00 am')
+    ehrUtils.formatTimeStr('2011-10-11T12:00').should.equal('2011-10-11 12:00 pm')
+    ehrUtils.formatTimeStr('2011-10-11T15:00').should.equal('2011-10-11 3:00 pm')
+    ehrUtils.formatTimeStr('2011-10-11T00:00').should.equal('2011-10-11 12:00 am')
     done()
   })
 

--- a/client/src/helpers/test/store-helper.spec.js
+++ b/client/src/helpers/test/store-helper.spec.js
@@ -292,17 +292,17 @@ describe('classList / instructor tests', () => {
   
   it('getCurrentEvaluationStudentId', done => {
     const studentEvalId = 'currentEvaluationStudentId'
-    testHelper.instructorCommit(studentEvalId, 'setCurrentEvaluationStudentId')
     should.doesNotThrow(() => testHelper.instructorCommit(studentEvalId, 'setCurrentEvaluationStudentId'))
-    const currentEval = StoreHelper.getCurrentEvaluationStudentId()
     should.doesNotThrow(() => StoreHelper.getCurrentEvaluationStudentId())
-    should.exist(studentEvalId)
+    const currentEval = StoreHelper.getCurrentEvaluationStudentId()
+    should.exist(currentEval)
     currentEval.should.equal(studentEvalId)
     done()
   })
   
   it('getCurrentEvaluationStudentVisit', done => {
     const studentEvalId = StoreHelper.getCurrentEvaluationStudentId()
+    should.doesNotThrow(() => testHelper.instructorCommit(studentEvalId, 'setCurrentEvaluationStudentId'))
     const currentVisit = StoreHelper.getCurrentEvaluationStudentVisit()
     should.doesNotThrow(() => StoreHelper.getCurrentEvaluationStudentVisit())
     currentVisit._id.should.equal(studentEvalId)
@@ -494,15 +494,6 @@ describe('activity tests', () => {
     should.doesNotThrow(async () => await StoreHelper.openActivity(mockData.activity._id))
     result.activity.should.equal(openedActivity)
     result.activity.closed.should.equal(false)
-    done()
-  })
-
-  it('currentStudentId', done => {
-    const currentStudentId = 'currStudentId'
-    testHelper.instructorCommit(currentStudentId, 'setCurrentEvaluationStudentId')
-    const id = StoreHelper.currentStudentId()
-    should.doesNotThrow(() => StoreHelper.currentStudentId())
-    id.should.equal(currentStudentId)
     done()
   })
 
@@ -725,21 +716,8 @@ describe('Loading / restoring tests', () => {
     done()
   })
 
-  it('restoreSession', async done => {
-    const { activity, visit } = mockData
-    const token = visit._id
-    sessionStorage.setItem(sKeys.USER_TOKEN, token)
-    await axiosMockHelper.prepareAxiosResponse('get', { activity })
-    const result = await StoreHelper.restoreSession()
-    should.doesNotThrow(async () => await StoreHelper.restoreSession())
-    result.should.equal(visit._id)
-    done()
-  })
-
   it('clearSession', done => {
     should.doesNotThrow(async () => await StoreHelper.clearSession())
-    should.not.exist(sessionStorage.getItem(sKeys.C_ACTIVITY))
-    should.not.exist(sessionStorage.getItem(sKeys.C_STUDENT))
     should.not.exist(sessionStorage.getItem(sKeys.SEED_ID))
     should.not.exist(sessionStorage.getItem(sKeys.IS_READONLY_INSTRUCTOR))
     done()

--- a/client/src/inside/components/EhrContextInstructor.vue
+++ b/client/src/inside/components/EhrContextInstructor.vue
@@ -77,9 +77,6 @@ export default {
       }
       return list
     },
-    currentStudentId () {
-      return StoreHelper.getCurrentEvaluationStudentId()
-    },
     showClassList () {
       return true
     },
@@ -105,7 +102,7 @@ export default {
     },
     findCurrent () {
       let list = this.classList
-      let id = this.currentStudentId
+      let id = StoreHelper.getCurrentEvaluationStudentId()
       return list.find(function (elem) { return elem._id === id }) || {}
     },
     previousStudent () {

--- a/client/src/outside/components/ClassList.vue
+++ b/client/src/outside/components/ClassList.vue
@@ -116,7 +116,7 @@ export default {
       return list
     },
 
-    cs () { return StoreHelper.currentStudentId()},
+    cs () { return StoreHelper.getCurrentEvaluationStudentId()},
 
     promptMessage () {
       return 'Save evaluations for ' + this.activityName
@@ -129,7 +129,7 @@ export default {
   },
   methods: {
     rowClass: function (sv) {
-      let selected = sv._id === StoreHelper.currentStudentId()
+      let selected = sv._id === StoreHelper.getCurrentEvaluationStudentId()
       return selected ? 'selected' : ''
     },
     evaluatedButtonText (sv) {

--- a/client/src/store/modules/activityDataStore.js
+++ b/client/src/store/modules/activityDataStore.js
@@ -3,7 +3,6 @@ import StoreHelper from '../../helpers/store-helper'
 import EventBus from '../../helpers/event-bus'
 import { ACTIVITY_DATA_EVENT } from '../../helpers/event-bus'
 import { Text } from '../../helpers/ehr-text'
-import { composeAxiosResponseError } from '../../helpers/ehr-utils'
 
 const API = 'activity-data'
 const OBJ = 'activitydata'

--- a/client/src/store/modules/activityStore.js
+++ b/client/src/store/modules/activityStore.js
@@ -1,6 +1,5 @@
 import InstoreHelper from './instoreHelper'
 import StoreHelper from '../../helpers/store-helper'
-import sKeys from '../../helpers/session-keys'
 import { Text } from '../../helpers/ehr-text'
 const API = 'activities'
 const OBJ = 'activity'
@@ -50,15 +49,6 @@ const getters = {
 }
 
 const actions = {
-  sessionRestore: ({dispatch}) => {
-    let actId = sessionStorage.getItem(sKeys.C_ACTIVITY)
-    if (actId) {
-      if(debug) console.log('ActivityStore restore current activity id', actId)
-      return dispatch('load', actId)
-    }
-    return Promise.resolve()
-  },
-
   close ({dispatch, commit}, id) {
     let url = 'close-activity/' + id
     let payload = { url:url, data: { }}
@@ -116,8 +106,6 @@ const actions = {
 const mutations = {
   set: (state, data) => {
     state.dataStore = data
-    let actId = data._id
-    sessionStorage.setItem(sKeys.C_ACTIVITY, actId)
   },
 
 }

--- a/client/src/store/modules/consumerStore.js
+++ b/client/src/store/modules/consumerStore.js
@@ -5,7 +5,6 @@ const API = 'consumers'
 const NAME = 'ConsumerStore'
 const OBJ = 'consumer'
 const debug = false
-const STASH_KEY = 'consumerId'
 
 const state = {
   dataStore: {}
@@ -13,9 +12,7 @@ const state = {
 
 const getters = {
   consumerId: state => {
-    let id = state.dataStore._id
-    id = id ? id : sessionStorage.getItem(STASH_KEY)
-    return id
+    return state.dataStore._id
   },
   lastUpdateDate: state => {
     let prop =  state.dataStore.lastUpdateDate
@@ -54,7 +51,6 @@ const actions = {
 
 const mutations = {
   set: (state, consumer) => {
-    if (consumer) sessionStorage.setItem(STASH_KEY, consumer._id)
     state.dataStore = consumer
   }
 }

--- a/client/src/store/modules/instructor.js
+++ b/client/src/store/modules/instructor.js
@@ -26,10 +26,8 @@ const getters = {
    */
   list: state => { return state.sClassList },
 
-  currentStudentId: state => {
-    let id = state.sCurrentEvaluationStudentId
-    id = id ? id :   sessionStorage.getItem(sKeys.C_STUDENT)
-    return id
+  currentEvaluationStudentId: state => {
+    return state.sCurrentEvaluationStudentId
   },
 
   currentEvaluationStudent: state => {
@@ -109,13 +107,6 @@ const actions = {
       })
   },
 
-  sessionRestore: (context) => {
-    let sid = sessionStorage.getItem(sKeys.C_STUDENT)
-    if (sid) {
-      context.commit('setCurrentEvaluationStudentId', sid)
-    }
-  },
-
 }
 
 const mutations = {
@@ -124,7 +115,6 @@ const mutations = {
   setCourses: (state, list) => { state.sCourses = list  },
 
   setCurrentEvaluationStudentId: (state, id) => {
-    sessionStorage.setItem(sKeys.C_STUDENT, id)
     state.sCurrentEvaluationStudentId = id
   }
 }

--- a/client/src/store/modules/instructor.js
+++ b/client/src/store/modules/instructor.js
@@ -1,5 +1,4 @@
 import InstoreHelper from './instoreHelper'
-import sKeys from '../../helpers/session-keys'
 const debug = false
 const NAME = 'InstStore '
 


### PR DESCRIPTION
remove unused import declarations
clean up duplications with instructor get current student id
remove unused  sessionRestore (etc)
in ehr-utils use ISO 8601 data to avoid deprecation warnings in console.
in consumerStore remove session store that is not needed.
remove the redundant local getter that does nothing but call the SH.