### PR TITLE
remove consumer secret from appearing in api

### DIFF
--- a/server/src/mcr/consumer/consumer-controller.js
+++ b/server/src/mcr/consumer/consumer-controller.js
@@ -88,7 +88,17 @@ export default class ConsumerController extends BaseController {
       })
   }
 
-
+  read (id) {
+    let self = this
+    return this.baseFindOneQuery(id)
+    .select('-oauth_consumer_secret')
+    .then((modelInstance) => {
+      console.log('read(id)  ', id, 'this.modelName', this.modelName, 'modelInstance', modelInstance, 'populate', self.populate)
+      var response = {}
+      response[this.modelName] = modelInstance
+      return response
+    })
+  }
 
   
   route () {

--- a/server/src/mcr/visit/visit.js
+++ b/server/src/mcr/visit/visit.js
@@ -23,7 +23,7 @@ const VisitSchema = new mongoose.Schema({
   isDeveloper: {type: Boolean, default: false},
   returnUrl: {type: String},
   /* Track the lti information that creates this visit to help resolve issues between LMS and EdEHR*/
-  ltiData: [ { type: String } ],
+  // ltiData: [ { type: String } ],
   createDate: {type: Date, default: Date.now},
   lastVisitDate: {type: Date, default: Date.now}
 })


### PR DESCRIPTION
removes the lti data stored in the visit record and query to get consumer drops the secret.
Closes #742

